### PR TITLE
Optimized for autocomplete+ snippets

### DIFF
--- a/snippets/adapters.cson
+++ b/snippets/adapters.cson
@@ -1,15 +1,15 @@
 '.source.coffee':
 
-  'Ember FixtureAdapter':
-    'prefix': 'em_adapter_fixture'
+  'Ember-data FixtureAdapter':
+    'prefix': 'ds_adapter_fixture'
     'body':
       """
         _export = DS.FixtureAdapter.extend()
       """
 
 
-  'Ember RESTAdapter':
-    'prefix': 'em_adapter_rest'
+  'Ember-data RESTAdapter':
+    'prefix': 'ds_adapter_rest'
     'body':
       """
         _export = DS.RESTAdapter.extend(
@@ -31,7 +31,7 @@
 
 
   'Ember ActiveModelAdapter':
-    'prefix': 'em_adapter_activeModel'
+    'prefix': 'ds_adapter_activeModel'
     'body':
       """
         _export = DS.ActiveModelAdapter.extend(

--- a/snippets/adapters.cson
+++ b/snippets/adapters.cson
@@ -1,0 +1,40 @@
+'.source.coffee':
+
+  'Ember fixtureAdapter':
+    'prefix': 'emAdapter.fixture'
+    'body':
+      """
+        export = DS.FixtureAdapter.extend()
+      """
+
+
+  'Ember REST Adapter':
+    'prefix': 'emAdapter.rest'
+    'body':
+      """
+        _export = DS.RESTAdapter.extend(
+          ${1:#body}
+        )
+
+
+        _export.reopenClass FIXTURES: [
+          {
+            id: 1
+            ${1}: "${2}"
+          }
+          {
+            id: 2
+            ${3}: "${4}"
+          }
+        ]
+      """
+
+
+  'Ember Active Model Adapter':
+    'prefix': 'emAdapter.activeModel'
+    'body':
+      """
+        _export = DS.ActiveModelAdapter.extend(
+          ${1:#body}
+        )
+      """

--- a/snippets/adapters.cson
+++ b/snippets/adapters.cson
@@ -1,15 +1,15 @@
 '.source.coffee':
 
-  'Ember fixtureAdapter':
-    'prefix': 'emAdapter.fixture'
+  'Ember FixtureAdapter':
+    'prefix': 'em_adapter_fixture'
     'body':
       """
-        export = DS.FixtureAdapter.extend()
+        _export = DS.FixtureAdapter.extend()
       """
 
 
-  'Ember REST Adapter':
-    'prefix': 'emAdapter.rest'
+  'Ember RESTAdapter':
+    'prefix': 'em_adapter_rest'
     'body':
       """
         _export = DS.RESTAdapter.extend(
@@ -30,8 +30,8 @@
       """
 
 
-  'Ember Active Model Adapter':
-    'prefix': 'emAdapter.activeModel'
+  'Ember ActiveModelAdapter':
+    'prefix': 'em_adapter_activeModel'
     'body':
       """
         _export = DS.ActiveModelAdapter.extend(

--- a/snippets/adapters.cson
+++ b/snippets/adapters.cson
@@ -1,15 +1,15 @@
 '.source.coffee':
 
-  'Ember-data FixtureAdapter':
-    'prefix': 'ds_adapter_fixture'
+  'Ember FixtureAdapter':
+    'prefix': 'adapter_fixture'
     'body':
       """
         _export = DS.FixtureAdapter.extend()
       """
 
 
-  'Ember-data RESTAdapter':
-    'prefix': 'ds_adapter_rest'
+  'Ember RESTAdapter':
+    'prefix': 'adapter_rest'
     'body':
       """
         _export = DS.RESTAdapter.extend(
@@ -31,7 +31,7 @@
 
 
   'Ember ActiveModelAdapter':
-    'prefix': 'ds_adapter_activeModel'
+    'prefix': 'adapter_activeModel'
     'body':
       """
         _export = DS.ActiveModelAdapter.extend(

--- a/snippets/adapters.cson
+++ b/snippets/adapters.cson
@@ -38,3 +38,46 @@
           ${1:#body}
         )
       """
+
+
+
+
+
+  'FixtureAdapter':
+    'prefix': 'fixture_adapter'
+    'body':
+      """
+        _export = DS.FixtureAdapter.extend()
+      """
+
+
+  'RESTAdapter':
+    'prefix': 'rest_adapter'
+    'body':
+      """
+        _export = DS.RESTAdapter.extend(
+          ${1:#body}
+        )
+
+
+        _export.reopenClass FIXTURES: [
+          {
+            id: 1
+            ${1}: "${2}"
+          }
+          {
+            id: 2
+            ${3}: "${4}"
+          }
+        ]
+      """
+
+
+  'ActiveModelAdapter':
+    'prefix': 'activemodel_adapter'
+    'body':
+      """
+        _export = DS.ActiveModelAdapter.extend(
+          ${1:#body}
+        )
+      """

--- a/snippets/computed.cson
+++ b/snippets/computed.cson
@@ -2,50 +2,50 @@
 
 
   'Ember.computed.gt(...':
-    'prefix': 'emComputed.gt'
-    'body': "Ember.computed.gt('${1:property}', ${2:0}) ${3:# (returns a boolean)}"
+    'prefix': 'em_computed_gt'
+    'body': "Ember.computed.gt( '${1:property}' , ${2:0} ) ${3:# (returns a boolean)}"
 
 
 
 
   'Ember.computed.lt(...':
-    'prefix': 'emComputed.lt'
-    'body': "Ember.computed.lt('${1:property}', ${2:0}) ${3:# (returns a boolean)}"
+    'prefix': 'em_computed_lt'
+    'body': "Ember.computed.lt( '${1:property}' , ${2:0} ) ${3:# (returns a boolean)}"
 
 
 
 
   'Ember.computed.or(...':
-    'prefix': 'emComputed.or'
-    'body': "Ember.computed.or('${1:property_1}', '${2:property_2}')  ${3:# (returns a boolean)}"
+    'prefix': 'em_computed_or'
+    'body': "Ember.computed.or( '${1:property_1}' , '${2:property_2}' )  ${3:# (returns a boolean)}"
 
 
 
 
   'Ember.computed.and(...':
-    'prefix': 'emComputed.and'
-    'body': "Ember.computed.and('${1:property_1}', '${2:property_2}')  ${3:# (returns a boolean)}"
+    'prefix': 'em_computed_and'
+    'body': "Ember.computed.and( '${1:property_1}' , '${2:property_2}' )  ${3:# (returns a boolean)}"
 
 
 
 
   'Ember.computed.max(...':
-    'prefix': 'emComputed.max'
-    'body': "Ember.computed.max('${1:array_property}') ${2:# (returns the max as a number)}"
+    'prefix': 'em_computed_max'
+    'body': "Ember.computed.max( '${1:array_property}' ) ${2:# (returns the max as a number)}"
 
 
 
 
   'Ember.computed.min(...':
-    'prefix': 'emComputed.min'
-    'body': "Ember.computed.min('${1:array_property}') ${2:# (returns the min as a number)}"
+    'prefix': 'em_computed_min'
+    'body': "Ember.computed.min( '${1:array_property}' ) ${2:# (returns the min as a number)}"
 
 
 
 
   'Ember.computed.map(...':
-    'prefix': 'emComputed.map'
-    'body': """ Ember.computed.map('${1:array_property}', (item, index) ->
+    'prefix': 'em_computed_map'
+    'body': """ Ember.computed.map( '${1:array_property}', (item, index) ->
           ${2:#example logic
           altered_item = item + "some_string"
           return altered_item }
@@ -57,17 +57,17 @@
 
 
   'Ember.computed.mapBy(...':
-    'prefix': 'emComputed.mapBy'
-    'body': "Ember.computed.mapBy('${1:array_of_objs}','${2:obj_key}')  ${3:# outputs a simple array[] of items} "
+    'prefix': 'em_computed_mapBy'
+    'body': "Ember.computed.mapBy( '${1:array_of_objs}','${2:obj_key}' )  ${3:# outputs a simple array[] of items} "
 
 
 
 
   'Ember.computed.filter(...':
-    'prefix': 'emComputed.filter'
+    'prefix': 'em_computed_filter'
     'body':
       """
-        Ember.computed.filter('${1:array_property}', ( item, index, array ) ->
+        Ember.computed.filter( '${1:array_property}', ( item, index, array ) ->
           ${2:#logic.. (should return a boolean)}
       """
 
@@ -75,12 +75,27 @@
 
 
   'Ember.computed.filterBy(...':
-    'prefix': 'emComputed.filterBy'
-    'body': "Ember.computed.filterBy('${1:array_of_objs}','${2:obj_key}', ${3:value})  ${4:#returns filtered array[]}"
+    'prefix': 'em_computed_filterBy'
+    'body': "Ember.computed.filterBy( '${1:array_of_objs}','${2:obj_key}', ${3:value} )  ${4:#returns filtered array[]}"
 
 
 
 
   'Ember.computed.empty(...':
-    'prefix': 'emComputed.empty'
-    'body': "Ember.computed.empty('${1:propery}')  ${2:#returns boolean}"
+    'prefix': 'em_computed_empty'
+    'body': "Ember.computed.empty( '${1:propery}' )  ${2:#returns boolean}"
+
+
+
+
+
+  'Ember.computed.match(...':
+    'prefix': 'em_computed_match'
+    'body': "Ember.computed.match( '${1:statement}' , /^${2:regex}$/ )    (# returns a boolean)"
+
+
+
+
+  'Ember.computed.alias(...':
+    'prefix': 'em_computed_alias'
+    'body': "Ember.computed.alias( '${1:statement}' )    (# returns a boolean)"

--- a/snippets/computed.cson
+++ b/snippets/computed.cson
@@ -1,0 +1,86 @@
+'.source.coffee':
+
+
+  'Ember.computed.gt(...':
+    'prefix': 'emComputed.gt'
+    'body': "Ember.computed.gt('${1:property}', ${2:0}) ${3:# (returns a boolean)}"
+
+
+
+
+  'Ember.computed.lt(...':
+    'prefix': 'emComputed.lt'
+    'body': "Ember.computed.lt('${1:property}', ${2:0}) ${3:# (returns a boolean)}"
+
+
+
+
+  'Ember.computed.or(...':
+    'prefix': 'emComputed.or'
+    'body': "Ember.computed.or('${1:property_1}', '${2:property_2}')  ${3:# (returns a boolean)}"
+
+
+
+
+  'Ember.computed.and(...':
+    'prefix': 'emComputed.and'
+    'body': "Ember.computed.and('${1:property_1}', '${2:property_2}')  ${3:# (returns a boolean)}"
+
+
+
+
+  'Ember.computed.max(...':
+    'prefix': 'emComputed.max'
+    'body': "Ember.computed.max('${1:array_property}') ${2:# (returns the max as a number)}"
+
+
+
+
+  'Ember.computed.min(...':
+    'prefix': 'emComputed.min'
+    'body': "Ember.computed.min('${1:array_property}') ${2:# (returns the min as a number)}"
+
+
+
+
+  'Ember.computed.map(...':
+    'prefix': 'emComputed.map'
+    'body': """ Ember.computed.map('${1:array_property}', (item, index) ->
+          ${2:#example logic
+          altered_item = item + "some_string"
+          return altered_item }
+
+        ${3:# outputs a new array}
+      """
+
+
+
+
+  'Ember.computed.mapBy(...':
+    'prefix': 'emComputed.mapBy'
+    'body': "Ember.computed.mapBy('${1:array_of_objs}','${2:obj_key}')  ${3:# outputs a simple array[] of items} "
+
+
+
+
+  'Ember.computed.filter(...':
+    'prefix': 'emComputed.filter'
+    'body':
+      """
+        Ember.computed.filter('${1:array_property}', ( item, index, array ) ->
+          ${2:#logic.. (should return a boolean)}
+      """
+
+
+
+
+  'Ember.computed.filterBy(...':
+    'prefix': 'emComputed.filterBy'
+    'body': "Ember.computed.filterBy('${1:array_of_objs}','${2:obj_key}', ${3:value})  ${4:#returns filtered array[]}"
+
+
+
+
+  'Ember.computed.empty(...':
+    'prefix': 'emComputed.empty'
+    'body': "Ember.computed.empty('${1:propery}')  ${2:#returns boolean}"

--- a/snippets/computed.cson
+++ b/snippets/computed.cson
@@ -2,49 +2,49 @@
 
 
   'Ember.computed.gt(...':
-    'prefix': 'em_computed_gt'
+    'prefix': 'computed_gt'
     'body': "Ember.computed.gt( '${1:property}' , ${2:0} ) ${3:# (returns a boolean)}"
 
 
 
 
   'Ember.computed.lt(...':
-    'prefix': 'em_computed_lt'
+    'prefix': 'computed_lt'
     'body': "Ember.computed.lt( '${1:property}' , ${2:0} ) ${3:# (returns a boolean)}"
 
 
 
 
   'Ember.computed.or(...':
-    'prefix': 'em_computed_or'
+    'prefix': 'computed_or'
     'body': "Ember.computed.or( '${1:property_1}' , '${2:property_2}' )  ${3:# (returns a boolean)}"
 
 
 
 
   'Ember.computed.and(...':
-    'prefix': 'em_computed_and'
+    'prefix': 'computed_and'
     'body': "Ember.computed.and( '${1:property_1}' , '${2:property_2}' )  ${3:# (returns a boolean)}"
 
 
 
 
   'Ember.computed.max(...':
-    'prefix': 'em_computed_max'
+    'prefix': 'computed_max'
     'body': "Ember.computed.max( '${1:array_property}' ) ${2:# (returns the max as a number)}"
 
 
 
 
   'Ember.computed.min(...':
-    'prefix': 'em_computed_min'
+    'prefix': 'computed_min'
     'body': "Ember.computed.min( '${1:array_property}' ) ${2:# (returns the min as a number)}"
 
 
 
 
   'Ember.computed.map(...':
-    'prefix': 'em_computed_map'
+    'prefix': 'computed_map'
     'body': """ Ember.computed.map( '${1:array_property}', (item, index) ->
           ${2:#example logic
           altered_item = item + "some_string"
@@ -57,14 +57,14 @@
 
 
   'Ember.computed.mapBy(...':
-    'prefix': 'em_computed_mapBy'
+    'prefix': 'computed_mapBy'
     'body': "Ember.computed.mapBy( '${1:array_of_objs}','${2:obj_key}' )  ${3:# outputs a simple array[] of items} "
 
 
 
 
   'Ember.computed.filter(...':
-    'prefix': 'em_computed_filter'
+    'prefix': 'computed_filter'
     'body':
       """
         Ember.computed.filter( '${1:array_property}', ( item, index, array ) ->
@@ -75,14 +75,14 @@
 
 
   'Ember.computed.filterBy(...':
-    'prefix': 'em_computed_filterBy'
+    'prefix': 'computed_filterBy'
     'body': "Ember.computed.filterBy( '${1:array_of_objs}','${2:obj_key}', ${3:value} )  ${4:#returns filtered array[]}"
 
 
 
 
   'Ember.computed.empty(...':
-    'prefix': 'em_computed_empty'
+    'prefix': 'computed_empty'
     'body': "Ember.computed.empty( '${1:propery}' )  ${2:#returns boolean}"
 
 
@@ -90,12 +90,12 @@
 
 
   'Ember.computed.match(...':
-    'prefix': 'em_computed_match'
+    'prefix': 'computed_match'
     'body': "Ember.computed.match( '${1:statement}' , /^${2:regex}$/ )    (# returns a boolean)"
 
 
 
 
   'Ember.computed.alias(...':
-    'prefix': 'em_computed_alias'
+    'prefix': 'computed_alias'
     'body': "Ember.computed.alias( '${1:statement}' )    (# returns a boolean)"

--- a/snippets/controller.cson
+++ b/snippets/controller.cson
@@ -2,7 +2,7 @@
 
 
   'Ember.ObjectController.extend(...':
-    'prefix': 'ObjectController'
+    'prefix': 'objectController'
     'body':
       """
         _export = Ember.ObjectController.extend(
@@ -16,7 +16,7 @@
 
 
   'Ember.ArrayController.extend(...':
-    'prefix': 'ArrayController'
+    'prefix': 'arrayController'
     'body':
       """
         _export = Ember.ArrayController.extend(
@@ -43,15 +43,33 @@
 
 
   'itemController : ...':
-    'prefix': 'ArrayController_itemController'
+    'prefix': 'arrayController_itemController'
     'body': "itemController : '${1:an_objController}'}"
 
 
   'sortProperties : ...':
-    'prefix': 'ArrayController_sortProperties'
+    'prefix': 'arrayController_sortProperties'
     'body': "sortProperties : ['${1:property}']}"
 
 
   'sortAscending : ...':
-    'prefix': 'ArrayController_sortAscending'
+    'prefix': 'arrayController_sortAscending'
+    'body': "sortAscending : ['${1:false}']}"
+
+
+
+
+
+  'itemController : ...':
+    'prefix': 'itemController'
+    'body': "itemController : '${1:an_objController}'}"
+
+
+  'sortProperties : ...':
+    'prefix': 'sortProperties'
+    'body': "sortProperties : ['${1:property}']}"
+
+
+  'sortAscending : ...':
+    'prefix': 'sortAscending'
     'body': "sortAscending : ['${1:false}']}"

--- a/snippets/controller.cson
+++ b/snippets/controller.cson
@@ -60,16 +60,16 @@
 
 
 
-  'itemController : ...':
+  'itemController: ...':
     'prefix': 'itemController'
     'body': "itemController : '${1:an_objController}'}"
 
 
-  'sortProperties : ...':
+  'sortProperties: ...':
     'prefix': 'sortProperties'
     'body': "sortProperties : ['${1:property}']}"
 
 
-  'sortAscending : ...':
+  'sortAscending: ...':
     'prefix': 'sortAscending'
     'body': "sortAscending : ['${1:false}']}"

--- a/snippets/controller.cson
+++ b/snippets/controller.cson
@@ -1,0 +1,46 @@
+'.source.coffee':
+
+
+  'Ember.ObjectController.extend(...':
+    'prefix': 'emObjectController'
+    'body':
+      """
+        _export = Ember.ObjectController.extend(
+          actions:
+            ${2:name}: ->
+              ${3:#logic...}
+        )
+      """
+
+
+
+
+  'Ember.ArrayController.extend(...':
+    'prefix': 'emArrayController'
+    'body':
+      """
+        _export = Ember.ArrayController.extend(
+          actions:
+            ${2:name}: ->
+              ${3:#logic...}
+
+        )
+      """
+
+
+
+
+
+  'itemController : ...':
+    'prefix': 'emArrayController.itemC'
+    'body': "itemController : '${1:an_objController}'}"
+
+
+  'sortProperties : ...':
+    'prefix': 'emArrayController.sortP'
+    'body': "sortProperties : ['${1:property}']}"
+
+
+  'sortAscending : ...':
+    'prefix': 'emArrayController.sortA'
+    'body': "sortAscending : ['${1:false}']}"

--- a/snippets/controller.cson
+++ b/snippets/controller.cson
@@ -2,7 +2,7 @@
 
 
   'Ember.ObjectController.extend(...':
-    'prefix': 'em_ObjectController'
+    'prefix': 'ObjectController'
     'body':
       """
         _export = Ember.ObjectController.extend(
@@ -14,22 +14,9 @@
 
 
 
-  'Ember.controller.extend(...':
-    'prefix': 'em_controller'
-    'body':
-      """
-        _export = Ember.controller.extend(
-          actions:
-            ${2:name}: ->
-              ${3:#logic...}
-        )
-      """
-
-
-
 
   'Ember.ArrayController.extend(...':
-    'prefix': 'em_ArrayController'
+    'prefix': 'ArrayController'
     'body':
       """
         _export = Ember.ArrayController.extend(
@@ -42,18 +29,29 @@
 
 
 
+  'Ember.controller.extend(...':
+    'prefix': 'controller'
+    'body':
+      """
+        _export = Ember.controller.extend(
+          actions:
+            ${2:name}: ->
+              ${3:#logic...}
+        )
+      """
+
 
 
   'itemController : ...':
-    'prefix': 'em_ArrayController_itemC'
+    'prefix': 'ArrayController_itemController'
     'body': "itemController : '${1:an_objController}'}"
 
 
   'sortProperties : ...':
-    'prefix': 'em_ArrayController_sortP'
+    'prefix': 'ArrayController_sortProperties'
     'body': "sortProperties : ['${1:property}']}"
 
 
   'sortAscending : ...':
-    'prefix': 'em_ArrayController_sortA'
+    'prefix': 'ArrayController_sortAscending'
     'body': "sortAscending : ['${1:false}']}"

--- a/snippets/controller.cson
+++ b/snippets/controller.cson
@@ -2,7 +2,7 @@
 
 
   'Ember.ObjectController.extend(...':
-    'prefix': 'emObjectController'
+    'prefix': 'em_ObjectController'
     'body':
       """
         _export = Ember.ObjectController.extend(
@@ -14,9 +14,22 @@
 
 
 
+  'Ember.controller.extend(...':
+    'prefix': 'em_controller'
+    'body':
+      """
+        _export = Ember.controller.extend(
+          actions:
+            ${2:name}: ->
+              ${3:#logic...}
+        )
+      """
+
+
+
 
   'Ember.ArrayController.extend(...':
-    'prefix': 'emArrayController'
+    'prefix': 'em_ArrayController'
     'body':
       """
         _export = Ember.ArrayController.extend(
@@ -32,15 +45,15 @@
 
 
   'itemController : ...':
-    'prefix': 'emArrayController.itemC'
+    'prefix': 'em_ArrayController_itemC'
     'body': "itemController : '${1:an_objController}'}"
 
 
   'sortProperties : ...':
-    'prefix': 'emArrayController.sortP'
+    'prefix': 'em_ArrayController_sortP'
     'body': "sortProperties : ['${1:property}']}"
 
 
   'sortAscending : ...':
-    'prefix': 'emArrayController.sortA'
+    'prefix': 'em_ArrayController_sortA'
     'body': "sortAscending : ['${1:false}']}"

--- a/snippets/es6.cson
+++ b/snippets/es6.cson
@@ -23,6 +23,17 @@
 
 
 
+  'import custom from...':
+    'prefix': 'emEs6.custom'
+    'body':
+      """
+        `import ${1:var} from './${2}';`
+        ${3}
+      """
+
+
+
+
   'export Default...':
     'prefix': 'emEs6.exportDefault'
     'body':

--- a/snippets/es6.cson
+++ b/snippets/es6.cson
@@ -2,7 +2,7 @@
 
 
   'import Ember from...':
-    'prefix': 'emEs6.importEmber'
+    'prefix': 'em_es6_importEmber'
     'body':
       """
         `import Ember from "ember";`
@@ -13,7 +13,7 @@
 
 
   'import DS from...':
-    'prefix': 'emEs6.importDs'
+    'prefix': 'em_es6_importDs'
     'body':
       """
         `import DS from 'ember-data';`
@@ -24,7 +24,7 @@
 
 
   'import custom from...':
-    'prefix': 'emEs6.custom'
+    'prefix': 'em_es6_custom'
     'body':
       """
         `import ${1:var} from './${2}';`
@@ -35,7 +35,7 @@
 
 
   'export Default...':
-    'prefix': 'emEs6.exportDefault'
+    'prefix': 'em_es6_exportDefault'
     'body':
       """
 
@@ -49,7 +49,7 @@
 
 
   'both imports and export...':
-    'prefix': 'emEs6.fullset'
+    'prefix': 'em_es6_fullset'
     'body':
       """
         ${1:`import Ember from 'ember';`}

--- a/snippets/es6.cson
+++ b/snippets/es6.cson
@@ -2,7 +2,7 @@
 
 
   'import Ember from...':
-    'prefix': 'em_es6_importEmber'
+    'prefix': 'es6_import_ember'
     'body':
       """
         `import Ember from "ember";`
@@ -13,7 +13,7 @@
 
 
   'import DS from...':
-    'prefix': 'em_es6_importDs'
+    'prefix': 'es6_import_ds'
     'body':
       """
         `import DS from 'ember-data';`
@@ -24,7 +24,7 @@
 
 
   'import custom from...':
-    'prefix': 'em_es6_custom'
+    'prefix': 'es6_custom'
     'body':
       """
         `import ${1:var} from './${2}';`
@@ -35,7 +35,7 @@
 
 
   'export Default...':
-    'prefix': 'em_es6_exportDefault'
+    'prefix': 'es6_export_default'
     'body':
       """
 
@@ -49,7 +49,7 @@
 
 
   'both imports and export...':
-    'prefix': 'em_es6_fullset'
+    'prefix': 'es6_fullset'
     'body':
       """
         ${1:`import Ember from 'ember';`}

--- a/snippets/es6.cson
+++ b/snippets/es6.cson
@@ -1,8 +1,16 @@
 '.source.coffee':
 
 
-  'import Ember from...':
+  'import Ember from':
     'prefix': 'es6_import_ember'
+    'body':
+      """
+        `import Ember from "ember";`
+        ${1}
+      """
+
+  'import Ember from...':
+    'prefix': 'import_ember'
     'body':
       """
         `import Ember from "ember";`
@@ -12,7 +20,7 @@
 
 
 
-  'import DS from...':
+  'import DS from':
     'prefix': 'es6_import_ds'
     'body':
       """
@@ -20,11 +28,17 @@
         ${1}
       """
 
+  'import DS from...':
+    'prefix': 'import_ds'
+    'body':
+      """
+        `import DS from 'ember-data';`
+        ${1}
+      """
 
 
-
-  'import custom from...':
-    'prefix': 'es6_custom'
+  'import custom from':
+    'prefix': 'es6_import_custom'
     'body':
       """
         `import ${1:var} from './${2}';`
@@ -32,10 +46,29 @@
       """
 
 
+  'import custom from...':
+    'prefix': 'import_custom'
+    'body':
+      """
+        `import ${1:var} from './${2}';`
+        ${3}
+      """
+
+  'export Default':
+    'prefix': 'es6_export_default'
+    'body':
+      """
+
+        ${2}
+
+
+        `export default ${1:_export};`
+      """
+
 
 
   'export Default...':
-    'prefix': 'es6_export_default'
+    'prefix': 'export_default'
     'body':
       """
 

--- a/snippets/es6.cson
+++ b/snippets/es6.cson
@@ -1,0 +1,55 @@
+'.source.coffee':
+
+
+  'import Ember from...':
+    'prefix': 'emEs6.importEmber'
+    'body':
+      """
+        `import Ember from "ember";`
+        ${1}
+      """
+
+
+
+
+  'import DS from...':
+    'prefix': 'emEs6.importDs'
+    'body':
+      """
+        `import DS from 'ember-data';`
+        ${1}
+      """
+
+
+
+
+  'export Default...':
+    'prefix': 'emEs6.exportDefault'
+    'body':
+      """
+
+        ${2}
+
+
+        `export default ${1:_export};`
+      """
+
+
+
+
+  'both imports and export...':
+    'prefix': 'emEs6.fullset'
+    'body':
+      """
+        ${1:`import Ember from 'ember';`}
+        ${2:`import DS    from 'ember-data';`}
+
+
+
+        ${3}
+
+
+
+        `export default _export;`
+
+      """

--- a/snippets/logger.cson
+++ b/snippets/logger.cson
@@ -2,40 +2,40 @@
 
 
   'Em.Logger.assert(... ':
-    'prefix': 'em_logger_assert'
+    'prefix': 'logger_assert'
     'body': "Ember.Logger.assert('${1:boolean}')   # Throws an Assertion failed error."
 
 
 
 
   'Em.Logger.debug(... ':
-    'prefix': 'em_logger_debug'
+    'prefix': 'logger_debug'
     'body': "Ember.Logger.debug('${1:message}')"
 
 
 
 
   'Em.Logger.log(...':
-    'prefix': 'em_logger_log'
+    'prefix': 'logger_log'
     'body': "Ember.Logger.log('${1:message}')"
 
 
 
 
   'Em.Logger.info(...':
-    'prefix': 'em_logger_info'
+    'prefix': 'logger_info'
     'body': "Ember.Logger.info('${1:message}')"
 
 
 
 
   'Em.Logger.warn(...':
-    'prefix': 'em_logger_warn'
+    'prefix': 'logger_warn'
     'body': "Ember.Logger.warn('${1:message}')"
 
 
 
 
   'Em.Logger.error(...':
-    'prefix': 'em_logger_error'
+    'prefix': 'logger_error'
     'body': "Ember.Logger.error('${1:message}')"

--- a/snippets/logger.cson
+++ b/snippets/logger.cson
@@ -1,41 +1,41 @@
 '.source.coffee':
 
 
-  'Em.Logger.assert(... ':
+  'Throws Assertion failed error if falsy':
     'prefix': 'logger_assert'
     'body': "Ember.Logger.assert('${1:boolean}')   # Throws an Assertion failed error."
 
 
 
 
-  'Em.Logger.debug(... ':
+  'Em.Logger.debug (Logs in blue)':
     'prefix': 'logger_debug'
-    'body': "Ember.Logger.debug('${1:message}')"
+    'body': "Ember.Logger.debug('${1:message}',${2:arg})"
 
 
 
 
-  'Em.Logger.log(...':
+  'Em.Logger.log (Logs to console)':
     'prefix': 'logger_log'
     'body': "Ember.Logger.log('${1:message}')"
 
 
 
 
-  'Em.Logger.info(...':
+  'Em.Logger.info (Logs to console)':
     'prefix': 'logger_info'
     'body': "Ember.Logger.info('${1:message}')"
 
 
 
 
-  'Em.Logger.warn(...':
+  'Em.Logger.warn (with warning icon)':
     'prefix': 'logger_warn'
     'body': "Ember.Logger.warn('${1:message}')"
 
 
 
 
-  'Em.Logger.error(...':
+  'Em.Logger.error (with error icon)':
     'prefix': 'logger_error'
     'body': "Ember.Logger.error('${1:message}')"

--- a/snippets/logger.cson
+++ b/snippets/logger.cson
@@ -2,40 +2,40 @@
 
 
   'Em.Logger.assert(... ':
-    'prefix': 'emLogger.assert'
+    'prefix': 'em_logger_assert'
     'body': "Ember.Logger.assert('${1:boolean}')   # Throws an Assertion failed error."
 
 
 
 
   'Em.Logger.debug(... ':
-    'prefix': 'emLogger.debug'
+    'prefix': 'em_logger_debug'
     'body': "Ember.Logger.debug('${1:message}')"
 
 
 
 
   'Em.Logger.log(...':
-    'prefix': 'emLogger.log'
+    'prefix': 'em_logger_log'
     'body': "Ember.Logger.log('${1:message}')"
 
 
 
 
   'Em.Logger.info(...':
-    'prefix': 'emLogger.info'
+    'prefix': 'em_logger_info'
     'body': "Ember.Logger.info('${1:message}')"
 
 
 
 
   'Em.Logger.warn(...':
-    'prefix': 'emLogger.warn'
+    'prefix': 'em_logger_warn'
     'body': "Ember.Logger.warn('${1:message}')"
 
 
 
 
   'Em.Logger.error(...':
-    'prefix': 'emLogger.error'
+    'prefix': 'em_logger_error'
     'body': "Ember.Logger.error('${1:message}')"

--- a/snippets/logger.cson
+++ b/snippets/logger.cson
@@ -1,6 +1,13 @@
 '.source.coffee':
 
 
+  'Em.Logger.assert(... ':
+    'prefix': 'emLogger.assert'
+    'body': "Ember.Logger.assert('${1:boolean}')   # Throws an Assertion failed error."
+
+
+
+
   'Em.Logger.debug(... ':
     'prefix': 'emLogger.debug'
     'body': "Ember.Logger.debug('${1:message}')"

--- a/snippets/logger.cson
+++ b/snippets/logger.cson
@@ -1,0 +1,34 @@
+'.source.coffee':
+
+
+  'Em.Logger.debug(... ':
+    'prefix': 'emLogger.debug'
+    'body': "Ember.Logger.debug('${1:message}')"
+
+
+
+
+  'Em.Logger.log(...':
+    'prefix': 'emLogger.log'
+    'body': "Ember.Logger.log('${1:message}')"
+
+
+
+
+  'Em.Logger.info(...':
+    'prefix': 'emLogger.info'
+    'body': "Ember.Logger.info('${1:message}')"
+
+
+
+
+  'Em.Logger.warn(...':
+    'prefix': 'emLogger.warn'
+    'body': "Ember.Logger.warn('${1:message}')"
+
+
+
+
+  'Em.Logger.error(...':
+    'prefix': 'emLogger.error'
+    'body': "Ember.Logger.error('${1:message}')"

--- a/snippets/model.cson
+++ b/snippets/model.cson
@@ -12,20 +12,38 @@
 
 
 
-  'DS.attr(...':
+  'Verbose DS.attr(...':
     'prefix': 'dsModel.attr'
-    'body': "${1}: DS.attr(  'string'  )     # or 'number' , 'boolean' , 'date'"
+    'body': "${1}: DS.attr(  'string' ,  defaultValue: ${2:null}  )     # or 'number' , 'boolean' , 'date'"
+
+
+  'DS.attr(...':
+    'prefix': 'dsModel.attr-v'
+    'body': "${1}: DS.attr()"
+
+
+
+
+
+  'Verbose DS.hasMany(...':
+    'prefix': 'dsModel.hasMany'
+    'body': "${1}: DS.hasMany(  '${2:other_Model}' , inverse: '${2:some_propery}' , async: ${3:false})"
+
+
+  'DS.hasMany(...':
+    'prefix': 'dsModel.hasMany'
+    'body': "${1}: DS.hasMany('${2:other_Model}')"
+
+
 
 
 
 
   'DS.belongsTo(...':
     'prefix': 'dsModel.belongsTo'
-    'body': "${1}: DS.belongsTo('${2:other_Model}',async: ${3:false})"
+    'body': "${1}: DS.belongsTo('${1:other_Model}')"
 
 
-
-
-  'DS.hasMany(...':
-    'prefix': 'dsModel.hasMany'
-    'body': "${1}: DS.hasMany('${2:other_Model}',async: ${3:false})"
+  'Verbose DS.belongsTo(...':
+    'prefix': 'dsModel.belongsTo-v'
+    'body': "${1}: DS.belongsTo('${1:other_Model}' , inverse: '${2:some_propery}' , async: ${3:false})"

--- a/snippets/model.cson
+++ b/snippets/model.cson
@@ -48,35 +48,31 @@
 
 
 
-
-
-
-
-  '-Verbose DS.attr(...':
+  'Verbose DS.attr( ...':
     'prefix': 'attr-v'
     'body': "${1}: DS.attr(  'string' ,  defaultValue:${2:null}  )     # or 'number' , 'boolean' , 'date'"
 
 
-  '-DS.attr(...':
+  'DS.attr( ...':
     'prefix': 'attr'
     'body': "${1}: DS.attr()"
 
 
-  '-Verbose DS.hasMany(...':
+  'Verbose DS.hasMany( ...':
     'prefix': 'hasMany-v'
     'body': "${1}: DS.hasMany(  '${2:other_Model}' , inverse:'${2:some_propery}' , async:${3:false} )"
 
 
-  '-DS.hasMany(...':
+  'DS.hasMany( ...':
     'prefix': 'hasMany'
     'body': "${1}: DS.hasMany( '${2:other_Model}' )"
 
 
-  '-DS.belongsTo(...':
+  'DS.belongsTo( ...':
     'prefix': 'belongsTo'
     'body': "${1}: DS.belongsTo( '${1:other_Model}' )"
 
 
-  '-Verbose DS.belongsTo(...':
+  'Verbose DS.belongsTo( ...':
     'prefix': 'belongsTo-v'
     'body': "${1}: DS.belongsTo( '${1:other_Model}' , inverse:'${2:some_propery}' , async:${3:false} )"

--- a/snippets/model.cson
+++ b/snippets/model.cson
@@ -2,7 +2,7 @@
 
 
   'DS.Model.extend(...':
-    'prefix': 'dsModel'
+    'prefix': 'ds_model'
     'body':
       """
         _export = DS.Model.extend
@@ -12,27 +12,30 @@
 
 
 
+
   'Verbose DS.attr(...':
-    'prefix': 'dsModel.attr'
-    'body': "${1}: DS.attr(  'string' ,  defaultValue: ${2:null}  )     # or 'number' , 'boolean' , 'date'"
+    'prefix': 'ds_model_attr-v'
+    'body': "${1}: DS.attr(  'string' ,  defaultValue:${2:null}  )     # or 'number' , 'boolean' , 'date'"
 
 
   'DS.attr(...':
-    'prefix': 'dsModel.attr-v'
+    'prefix': 'ds_model_attr'
     'body': "${1}: DS.attr()"
 
 
 
 
 
+
   'Verbose DS.hasMany(...':
-    'prefix': 'dsModel.hasMany'
-    'body': "${1}: DS.hasMany(  '${2:other_Model}' , inverse: '${2:some_propery}' , async: ${3:false})"
+    'prefix': 'ds_model_hasMany-v'
+    'body': "${1}: DS.hasMany(  '${2:other_Model}' , inverse:'${2:some_propery}' , async:${3:false} )"
 
 
   'DS.hasMany(...':
-    'prefix': 'dsModel.hasMany'
-    'body': "${1}: DS.hasMany('${2:other_Model}')"
+    'prefix': 'ds_model_hasMany'
+    'body': "${1}: DS.hasMany( '${2:other_Model}' )"
+
 
 
 
@@ -40,10 +43,10 @@
 
 
   'DS.belongsTo(...':
-    'prefix': 'dsModel.belongsTo'
-    'body': "${1}: DS.belongsTo('${1:other_Model}')"
+    'prefix': 'ds_model_belongsTo'
+    'body': "${1}: DS.belongsTo( '${1:other_Model}' )"
 
 
   'Verbose DS.belongsTo(...':
-    'prefix': 'dsModel.belongsTo-v'
-    'body': "${1}: DS.belongsTo('${1:other_Model}' , inverse: '${2:some_propery}' , async: ${3:false})"
+    'prefix': 'ds_model_belongsTo-v'
+    'body': "${1}: DS.belongsTo( '${1:other_Model}' , inverse:'${2:some_propery}' , async:${3:false} )"

--- a/snippets/model.cson
+++ b/snippets/model.cson
@@ -10,9 +10,6 @@
       """
 
 
-
-
-
   'Verbose DS.attr(...':
     'prefix': 'model_attr-v'
     'body': "${1}: DS.attr(  'string' ,  defaultValue:${2:null}  )     # or 'number' , 'boolean' , 'date'"
@@ -36,43 +33,9 @@
 
   'DS.belongsTo(...':
     'prefix': 'model_belongsTo'
-    'body': "${1}: DS.belongsTo( '${1:other_Model}' )"
+    'body': "${1}: DS.belongsTo( '${2:other_Model}' )"
 
 
   'Verbose DS.belongsTo(...':
     'prefix': 'model_belongsTo-v'
-    'body': "${1}: DS.belongsTo( '${1:other_Model}' , inverse:'${2:some_propery}' , async:${3:false} )"
-
-
-
-
-
-
-  'Verbose DS.attr( ...':
-    'prefix': 'attr-v'
-    'body': "${1}: DS.attr(  'string' ,  defaultValue:${2:null}  )     # or 'number' , 'boolean' , 'date'"
-
-
-  'DS.attr( ...':
-    'prefix': 'attr'
-    'body': "${1}: DS.attr()"
-
-
-  'Verbose DS.hasMany( ...':
-    'prefix': 'hasMany-v'
-    'body': "${1}: DS.hasMany(  '${2:other_Model}' , inverse:'${2:some_propery}' , async:${3:false} )"
-
-
-  'DS.hasMany( ...':
-    'prefix': 'hasMany'
-    'body': "${1}: DS.hasMany( '${2:other_Model}' )"
-
-
-  'DS.belongsTo( ...':
-    'prefix': 'belongsTo'
-    'body': "${1}: DS.belongsTo( '${1:other_Model}' )"
-
-
-  'Verbose DS.belongsTo( ...':
-    'prefix': 'belongsTo-v'
-    'body': "${1}: DS.belongsTo( '${1:other_Model}' , inverse:'${2:some_propery}' , async:${3:false} )"
+    'body': "${1}: DS.belongsTo( '${2:other_Model}' , inverse:'${3:some_propery}' , async:${4:false} )"

--- a/snippets/model.cson
+++ b/snippets/model.cson
@@ -1,0 +1,31 @@
+'.source.coffee':
+
+
+  'DS.Model.extend(...':
+    'prefix': 'dsModel'
+    'body':
+      """
+        _export = DS.Model.extend
+          ${1}
+      """
+
+
+
+
+  'DS.attr(...':
+    'prefix': 'dsModel.attr'
+    'body': "${1}: DS.attr(  'string'  )     # or 'number' , 'boolean' , 'date'"
+
+
+
+
+  'DS.belongsTo(...':
+    'prefix': 'dsModel.belongsTo'
+    'body': "${1}: DS.belongsTo('${2:other_Model}',async: ${3:false})"
+
+
+
+
+  'DS.hasMany(...':
+    'prefix': 'dsModel.hasMany'
+    'body': "${1}: DS.hasMany('${2:other_Model}',async: ${3:false})"

--- a/snippets/model.cson
+++ b/snippets/model.cson
@@ -23,10 +23,6 @@
     'body': "${1}: DS.attr()"
 
 
-
-
-
-
   'Verbose DS.hasMany(...':
     'prefix': 'model_hasMany-v'
     'body': "${1}: DS.hasMany(  '${2:other_Model}' , inverse:'${2:some_propery}' , async:${3:false} )"
@@ -38,10 +34,6 @@
 
 
 
-
-
-
-
   'DS.belongsTo(...':
     'prefix': 'model_belongsTo'
     'body': "${1}: DS.belongsTo( '${1:other_Model}' )"
@@ -49,4 +41,42 @@
 
   'Verbose DS.belongsTo(...':
     'prefix': 'model_belongsTo-v'
+    'body': "${1}: DS.belongsTo( '${1:other_Model}' , inverse:'${2:some_propery}' , async:${3:false} )"
+
+
+
+
+
+
+
+
+
+
+  '-Verbose DS.attr(...':
+    'prefix': 'attr-v'
+    'body': "${1}: DS.attr(  'string' ,  defaultValue:${2:null}  )     # or 'number' , 'boolean' , 'date'"
+
+
+  '-DS.attr(...':
+    'prefix': 'attr'
+    'body': "${1}: DS.attr()"
+
+
+  '-Verbose DS.hasMany(...':
+    'prefix': 'hasMany-v'
+    'body': "${1}: DS.hasMany(  '${2:other_Model}' , inverse:'${2:some_propery}' , async:${3:false} )"
+
+
+  '-DS.hasMany(...':
+    'prefix': 'hasMany'
+    'body': "${1}: DS.hasMany( '${2:other_Model}' )"
+
+
+  '-DS.belongsTo(...':
+    'prefix': 'belongsTo'
+    'body': "${1}: DS.belongsTo( '${1:other_Model}' )"
+
+
+  '-Verbose DS.belongsTo(...':
+    'prefix': 'belongsTo-v'
     'body': "${1}: DS.belongsTo( '${1:other_Model}' , inverse:'${2:some_propery}' , async:${3:false} )"

--- a/snippets/model.cson
+++ b/snippets/model.cson
@@ -2,7 +2,7 @@
 
 
   'DS.Model.extend(...':
-    'prefix': 'ds_model'
+    'prefix': 'model'
     'body':
       """
         _export = DS.Model.extend
@@ -14,12 +14,12 @@
 
 
   'Verbose DS.attr(...':
-    'prefix': 'ds_model_attr-v'
+    'prefix': 'model_attr-v'
     'body': "${1}: DS.attr(  'string' ,  defaultValue:${2:null}  )     # or 'number' , 'boolean' , 'date'"
 
 
   'DS.attr(...':
-    'prefix': 'ds_model_attr'
+    'prefix': 'model_attr'
     'body': "${1}: DS.attr()"
 
 
@@ -28,12 +28,12 @@
 
 
   'Verbose DS.hasMany(...':
-    'prefix': 'ds_model_hasMany-v'
+    'prefix': 'model_hasMany-v'
     'body': "${1}: DS.hasMany(  '${2:other_Model}' , inverse:'${2:some_propery}' , async:${3:false} )"
 
 
   'DS.hasMany(...':
-    'prefix': 'ds_model_hasMany'
+    'prefix': 'model_hasMany'
     'body': "${1}: DS.hasMany( '${2:other_Model}' )"
 
 
@@ -43,10 +43,10 @@
 
 
   'DS.belongsTo(...':
-    'prefix': 'ds_model_belongsTo'
+    'prefix': 'model_belongsTo'
     'body': "${1}: DS.belongsTo( '${1:other_Model}' )"
 
 
   'Verbose DS.belongsTo(...':
-    'prefix': 'ds_model_belongsTo-v'
+    'prefix': 'model_belongsTo-v'
     'body': "${1}: DS.belongsTo( '${1:other_Model}' , inverse:'${2:some_propery}' , async:${3:false} )"

--- a/snippets/route.cson
+++ b/snippets/route.cson
@@ -1,0 +1,41 @@
+'.source.coffee':
+
+  'Ember.Route.extend(...':
+    'prefix': 'emRoute'
+    'body':
+      """
+        _export = Ember.Route.extend(
+        model: ->
+          ${2}
+        )
+      """
+
+
+
+  'afterModel: ...':
+    'prefix': 'emRoute.afterModel'
+    'body':
+      """
+        afterModel: (${1:model}, transition) ->
+          ${2:#logic...}
+      """
+
+
+
+  'beforeModel: ...':
+    'prefix': 'emRoute.beforeModel'
+    'body':
+      """
+        beforeModel: (transition) ->
+          ${1:#logic...}
+      """
+
+
+
+  'setupController: ...':
+    'prefix': 'emRoute.setupController'
+    'body':
+      """
+        setupController: (transition) ->
+          ${1:#logic...}
+      """

--- a/snippets/route.cson
+++ b/snippets/route.cson
@@ -5,7 +5,7 @@
     'body':
       """
         _export = Ember.Route.extend(
-        model: ->
+          model: ->
           ${2}
         )
       """

--- a/snippets/route.cson
+++ b/snippets/route.cson
@@ -1,7 +1,7 @@
 '.source.coffee':
 
   'Ember.Route.extend(...':
-    'prefix': 'em_route'
+    'prefix': 'route'
     'body':
       """
         _export = Ember.Route.extend(
@@ -13,7 +13,7 @@
 
 
   'afterModel: ...':
-    'prefix': 'em_route_afterModel'
+    'prefix': 'route_afterModel'
     'body':
       """
         afterModel: (${1:model}, transition) ->
@@ -23,7 +23,7 @@
 
 
   'beforeModel: ...':
-    'prefix': 'em_route_beforeModel'
+    'prefix': 'route_beforeModel'
     'body':
       """
         beforeModel: (transition) ->
@@ -33,7 +33,7 @@
 
 
   'setupController: ...':
-    'prefix': 'em_route_setupController'
+    'prefix': 'route_setupController'
     'body':
       """
         setupController: (transition) ->

--- a/snippets/route.cson
+++ b/snippets/route.cson
@@ -1,7 +1,7 @@
 '.source.coffee':
 
   'Ember.Route.extend(...':
-    'prefix': 'emRoute'
+    'prefix': 'em_route'
     'body':
       """
         _export = Ember.Route.extend(
@@ -13,7 +13,7 @@
 
 
   'afterModel: ...':
-    'prefix': 'emRoute.afterModel'
+    'prefix': 'em_route_afterModel'
     'body':
       """
         afterModel: (${1:model}, transition) ->
@@ -23,7 +23,7 @@
 
 
   'beforeModel: ...':
-    'prefix': 'emRoute.beforeModel'
+    'prefix': 'em_route_beforeModel'
     'body':
       """
         beforeModel: (transition) ->
@@ -33,7 +33,7 @@
 
 
   'setupController: ...':
-    'prefix': 'emRoute.setupController'
+    'prefix': 'em_route_setupController'
     'body':
       """
         setupController: (transition) ->

--- a/snippets/router.cson
+++ b/snippets/router.cson
@@ -1,0 +1,8 @@
+'.source.coffee':
+  'Nested resource':
+    'prefix': 'emRouter.@resource'
+    'body':
+      """
+        @resource( '${1:name}' , path: '${2:/some/item_id}' ) , ->
+          @route "route_name"
+      """

--- a/snippets/router.cson
+++ b/snippets/router.cson
@@ -6,3 +6,12 @@
         @resource( '${1:name}' , path: '${2:/some/item_id}' ) , ->
           @route "route_name"
       """
+      
+  'verbose route':
+    'prefix': 'em_router_@route-v'
+    'body':  "@route('${1:name}', path:'${2:/some/item_id}')"
+    
+    
+  'verbose @route':
+    'prefix': '@route-v'
+    'body':  "@route('${1:name}', path:'${2:/some/item_id}')"

--- a/snippets/router.cson
+++ b/snippets/router.cson
@@ -1,17 +1,21 @@
 '.source.coffee':
-  'Nested resource':
+  'Verbose resource (Nested)':
     'prefix': '@resource-v'
     'body':
       """
-        @resource( '${1:name}' , path: '${2:/some/item_id}' ) , ->
-          @route "route_name"
+        @resource( '${1}' , path: '${2:/some/path/item_id}' ) , ->
+          @route '${3}'
       """
+      
+  'Simple resource':
+    'prefix': '@resource'
+    'body':"@resource( '${1}' )"
 
-  'verbose route':
+  'Verbose @route':
     'prefix': '@route-v'
-    'body':  "@route('${1:name}', path:'${2:/some/item_id}')"
+    'body':  "@route('${1}', path:'${2:/some/path}')"
 
-  'verbose @route':
-    'prefix': '@route-v'
-    'body':  "@route('${1:name}', path:'${2:/some/item_id}')"
+  'Simple @route':
+    'prefix': '@route'
+    'body':  "@route('${1}')"
 

--- a/snippets/router.cson
+++ b/snippets/router.cson
@@ -1,21 +1,14 @@
 '.source.coffee':
-  
-  'Verbose resource (Nested)':
-    'prefix': '@resource-v'
+
+  'Nested @resource':
+    'prefix': 'resource-v'
     'body':
       """
-        @resource( '${1}' , path: '${2:/some/path/item_id}' ) , ->
+        resource( '${1}' , path: '${2:/some/path/item_id}' ) , ->
           @route '${3}'
       """
-      
-  'Simple resource':
-    'prefix': '@resource'
-    'body':"@resource( '${1}' )"
 
-  'Verbose @route':
-    'prefix': '@route-v'
-    'body':  "@route('${1}', path:'${2:/some/path}')"
 
-  'Simple @route':
-    'prefix': '@route'
-    'body':  "@route('${1}')"
+  'Simple @resource':
+    'prefix': 'resource'
+    'body':"resource( '${1}' )"

--- a/snippets/router.cson
+++ b/snippets/router.cson
@@ -1,6 +1,6 @@
 '.source.coffee':
   'Nested resource':
-    'prefix': 'emRouter.@resource'
+    'prefix': 'em_router_@resource'
     'body':
       """
         @resource( '${1:name}' , path: '${2:/some/item_id}' ) , ->

--- a/snippets/router.cson
+++ b/snippets/router.cson
@@ -1,17 +1,17 @@
 '.source.coffee':
   'Nested resource':
-    'prefix': 'em_router_@resource'
+    'prefix': '@resource-v'
     'body':
       """
         @resource( '${1:name}' , path: '${2:/some/item_id}' ) , ->
           @route "route_name"
       """
-      
+
   'verbose route':
-    'prefix': 'em_router_@route-v'
+    'prefix': '@route-v'
     'body':  "@route('${1:name}', path:'${2:/some/item_id}')"
-    
-    
+
   'verbose @route':
     'prefix': '@route-v'
     'body':  "@route('${1:name}', path:'${2:/some/item_id}')"
+

--- a/snippets/router.cson
+++ b/snippets/router.cson
@@ -1,4 +1,5 @@
 '.source.coffee':
+  
   'Verbose resource (Nested)':
     'prefix': '@resource-v'
     'body':
@@ -18,4 +19,3 @@
   'Simple @route':
     'prefix': '@route'
     'body':  "@route('${1}')"
-

--- a/snippets/run.cson
+++ b/snippets/run.cson
@@ -1,0 +1,111 @@
+'.source.coffee':
+
+  'run.bind (target, method, args*)':
+    'prefix': 'run_bind'
+    'body': "Ember.run.bind( ${1:myContext} , ${2:myFunc} )"
+
+
+
+
+  'run.begin (Begins a new RunLoop)':
+    'prefix': 'run_begin'
+    'body': "Ember.run.begin()"
+
+
+
+
+  'run.cancel (Cancels a scheduled item)':
+    'prefix': 'run_cancel'
+    'body': "Ember.run.cancel( ${1:scheduled} )"
+
+
+
+
+  'run.debounce (target, method, args*, wait(ms), immediate)':
+    'prefix': 'run_debounce'
+    'body': "Ember.run.debounce( ${1:myContext} , ${2:myFunc} , ${3:150} )"
+
+
+
+
+  'run.end (Ends a run loop)':
+    'prefix': 'run_end'
+    'body': "Ember.run.end()"
+
+
+
+
+  'run.join (target, method, args*)':
+    'prefix': 'run_join'
+    'body': "Ember.run.join( () -> ${1} )"
+
+
+
+
+  'run.later (target, method, args*, wait)':
+    'prefix': 'run_later'
+    'body':
+      """
+        Ember.run.later( myContext , () ->
+          ${1:# code here will execute within a RunLoop in about 500ms with this == myContext}
+        , ${2:500})
+      """
+
+
+
+
+  'run.next (target, method, args*)':
+    'prefix': 'run_next'
+    'body': "Ember.run.next()"
+
+
+
+
+  'run.once (Schedule a function to run one time)':
+    'prefix': 'run_once'
+    'body':
+      """
+        Ember.run.once( ${1:context} ,
+          () ->
+            ${2:#logic}
+        )
+      """
+
+
+
+
+  'run.queues (Array of named queues)':
+    'prefix': 'run_queues'
+    'body':"Ember.run.queues()"
+
+
+
+  'run.schedule (queue, target, method, args*)':
+    'prefix': 'run_schedule'
+    'body':
+      """
+        Ember.run.schedule "${1:sync}", this, ->
+          ${2}
+      """
+
+
+  'run.scheduleOnce (queue, target, method, args*)':
+    'prefix': 'run_scheduleOnce'
+    'body':
+      """
+        Ember.run.scheduleOnce( ${1:'actions'} , ${2:myContext} , () ->
+          #logic
+        )
+      """
+
+
+
+  'run.sync (flushes events scheduled in sync queue.)':
+    'prefix': 'run_sync'
+    'body': "Ember.run.sync()"
+
+
+
+  'run.throttle ( target, method, args*, spacing(ms), immediate(bool) )':
+    'prefix': 'run_throttle'
+    'body': "Ember.run.throttle(${1:myContext} , ${2:myFunc} , ${3:200})"

--- a/snippets/store.cson
+++ b/snippets/store.cson
@@ -5,7 +5,7 @@
 
 
   'Ember Create Record on client':
-    'prefix': 'store.createRecord'
+    'prefix': 'store_createRecord'
     'body':
        """
         store.createRecord('${1:property}',
@@ -20,7 +20,7 @@
 
 
   'Ember Delete on client':
-    'prefix': 'store.deleteRecord'
+    'prefix': 'store_deleteRecord'
     'body':
        """
         store.deleteRecord(${1:data},
@@ -31,7 +31,7 @@
 
 
   'Ember Fetch from server':
-    'prefix': 'store.fetch'
+    'prefix': 'store_fetch'
     'body':
       """
         store.fetch('${1:model_name}',${2:params.id},false)
@@ -41,7 +41,7 @@
 
 
   'Ember filter':
-    'prefix': 'store.filter'
+    'prefix': 'store_filter'
     'body':
       """
         store.filter('${1:model_name}', (item) ->
@@ -54,14 +54,14 @@
 
 
   'Ember Push One Record':
-    'prefix': 'store.push'
+    'prefix': 'store_push'
     'body': """store.push('${1:model_name}', ${2:arr_of_objs})"""
 
 
 
 
   'Ember Push Many Records':
-    'prefix': 'store.pushMany'
+    'prefix': 'store_pushMany'
     'body':
       """store.pushMany('${1:model_name}', ${2:arr_of_objs})"""
 
@@ -69,19 +69,19 @@
 
 
   'Ember all Records':
-    'prefix': 'store.all'
+    'prefix': 'store_all'
     'body':"""store.all('${1:model_name}') # (only local)"""
 
 
 
 
   'Ember getById on client':
-    'prefix': 'store.getById'
+    'prefix': 'store_getById'
     'body': """store.getById('${1:model_name}', ${2:id} )   ${3:# only local}"""
 
 
 
   'Ember find Records from both':
-    'prefix': 'store.find'
+    'prefix': 'store_find'
     'body':
       """store.find('${1:model_name}'${2:, id})   ${3:#find records (local & remote)}"""

--- a/snippets/store.cson
+++ b/snippets/store.cson
@@ -1,0 +1,87 @@
+'.source.coffee':
+
+
+
+
+
+  'Ember Create Record on client':
+    'prefix': 'store.createRecord'
+    'body':
+       """
+        store.createRecord('${1:property}',
+
+          ${1:key} : ${2:value}
+        )
+
+        ${3}
+      """
+
+
+
+
+  'Ember Delete on client':
+    'prefix': 'store.deleteRecord'
+    'body':
+       """
+        store.deleteRecord(${1:data},
+        ${2}
+      """
+
+
+
+
+  'Ember Fetch from server':
+    'prefix': 'store.fetch'
+    'body':
+      """
+        store.fetch('${1:model_name}',${2:params.id},false)
+      """
+
+
+
+
+  'Ember filter':
+    'prefix': 'store.filter'
+    'body':
+      """
+        store.filter('${1:model_name}', (item) ->
+          #logic...
+          #return boolean
+        )
+      """
+
+
+
+
+  'Ember Push One Record':
+    'prefix': 'store.push'
+    'body': """store.push('${1:model_name}', ${2:arr_of_objs})"""
+
+
+
+
+  'Ember Push Many Records':
+    'prefix': 'store.pushMany'
+    'body':
+      """store.pushMany('${1:model_name}', ${2:arr_of_objs})"""
+
+
+
+
+  'Ember all Records':
+    'prefix': 'store.all'
+    'body':"""store.all('${1:model_name}') # (only local)"""
+
+
+
+
+  'Ember getById on client':
+    'prefix': 'store.getById'
+    'body': """store.getById('${1:model_name}', ${2:id} )   ${3:# only local}"""
+
+
+
+  'Ember find Records from both':
+    'prefix': 'store.find'
+    'body':
+      """store.find('${1:model_name}'${2:, id})   ${3:#find records (local & remote)}"""

--- a/snippets/view.cson
+++ b/snippets/view.cson
@@ -1,0 +1,79 @@
+'.source.coffee':
+
+
+  'Ember.View.extend(...':
+    'prefix': 'emView'
+    'body':
+      """
+        _export = Ember.View.extend(
+          ${1:# to see more available snippets by Expanding :
+
+          # view-help${2}  (or view-h)
+          }
+        )
+      """
+
+  'eventManager: ':
+    'prefix': 'emView.eventM'
+    'body':
+      """
+        eventManager: Ember.Object.create(
+          ${1:event} :
+            ${2:#logic...}
+        )
+      """
+
+
+
+
+  'tagNames : "div"':
+    'prefix': 'emView.tagN'
+    'body':
+      """
+        tagNames: '${1:div}'
+        ${2}
+      """
+
+
+
+
+  'attributeBindings : [...':
+    'prefix': 'emView.attrB'
+    'body':
+      """
+        attributeBindings: ['${1}']
+        ${2}
+      """
+
+
+
+
+  'classNames : [...':
+    'prefix': 'emView.classN'
+    'body':
+      """
+        classNames: ['${1:class-1}','${2:class-2}']
+        ${2}
+      """
+
+
+
+
+  'classNameBindings : [...':
+    'prefix': 'emView.classNB'
+    'body':
+      """
+        classNameBindings: ['${1}','${2}']
+        ${1} :
+        ${2} :
+      """
+
+
+
+
+  'isVisible : null':
+    'prefix': 'emView.isVisible'
+    'body':
+      """
+        isVisible: ${1:null}
+      """

--- a/snippets/view.cson
+++ b/snippets/view.cson
@@ -2,7 +2,7 @@
 
 
   'Ember.View.extend(...':
-    'prefix': 'em_view'
+    'prefix': 'view'
     'body':
       """
         _export = Ember.View.extend(
@@ -12,9 +12,8 @@
 
 
 
-
   'Ember.TextField.extend(...':
-    'prefix': 'em_view_textField'
+    'prefix': 'view_textField'
     'body':
       """
         Ember.TextField.extend
@@ -25,7 +24,7 @@
 
 
   'Ember.TextArea.extend(...':
-    'prefix': 'em_view_textArea'
+    'prefix': 'view_textArea'
     'body':
       """
         Ember.TextArea.extend
@@ -36,7 +35,7 @@
 
 
   'Ember.Checkbox.extend(...':
-    'prefix': 'em_view_checkbox'
+    'prefix': 'view_checkbox'
     'body':
       """
         Ember.Checkbox.extend
@@ -47,7 +46,7 @@
 
 
   'Ember.Select.extend(...':
-    'prefix': 'em_view_Select'
+    'prefix': 'view_Select'
     'body':
       """
         Ember.Select.extend
@@ -58,7 +57,7 @@
 
 
   'eventManager: ...':
-    'prefix': 'em_view_eventManager'
+    'prefix': 'view_eventManager'
     'body':
       """
         eventManager: Ember.Object.create(
@@ -71,7 +70,7 @@
 
 
   'tagName : null':
-    'prefix': 'em_view_tagN'
+    'prefix': 'view_tagName'
     'body':
       """
         tagName: '${1:div}'
@@ -82,7 +81,7 @@
 
 
   'attributeBindings : [...':
-    'prefix': 'em_view_attrB'
+    'prefix': 'view_attributeB'
     'body':
       """
         attributeBindings: ['${1:prop_to}:${2:attr}']
@@ -93,7 +92,7 @@
 
 
   'classNames : [...':
-    'prefix': 'em_view_classN'
+    'prefix': 'view_className'
     'body':
       """
         classNames: ['${1:class-1}','${2:class-2}']
@@ -104,7 +103,7 @@
 
 
   'classNameBindings : [...':
-    'prefix': 'em_view_classNB'
+    'prefix': 'view_classNameB'
     'body':
       """
         classNameBindings: ['${1:property_1:TruthyClass:FalsyClass}']
@@ -115,7 +114,7 @@
 
 
   'isVisible : null':
-    'prefix': 'em_view_isVisible'
+    'prefix': 'view_isVisible'
     'body':
       """
         isVisible: ${1:null}
@@ -124,17 +123,18 @@
 
 
   'Ember willInsertElement Hook':
-    'prefix': 'em_view_willInsertE'
+    'prefix': 'view_willInsertElement'
     'body':
       """
         willInsertElement: ->
+          @_super
           ${1:#logic...}
       """
 
 
 
   'Ember didInsertElement Hook':
-    'prefix': 'em_view_didInsertE'
+    'prefix': 'view_didInsertElement'
     'body':
       """
         didInsertElement: ->
@@ -144,7 +144,7 @@
 
 
   'Ember willDestroyElement Hook':
-    'prefix': 'em_view_willDestroyElement'
+    'prefix': 'view_willDestroyElement'
     'body':
       """
         willDestroyElement: ->
@@ -154,7 +154,7 @@
 
 
   'Ember parentViewDidChange Hook':
-    'prefix': 'em_view_parentViewDidC'
+    'prefix': 'view_parentViewDidC'
     'body':
       """
         parentViewDidChange: ->
@@ -164,7 +164,7 @@
 
 
   'Ember willClearRender Hook':
-    'prefix': 'em_view_willClearR'
+    'prefix': 'view_willClearR'
     'body':
       """
         willClearRender: ->

--- a/snippets/view.cson
+++ b/snippets/view.cson
@@ -14,7 +14,7 @@
 
 
   'Ember.TextField.extend(...':
-    'prefix': 'emView.TextField'
+    'prefix': 'emView_TextField'
     'body':
       """
         Ember.TextField.extend
@@ -25,7 +25,7 @@
 
 
   'Ember.TextArea.extend(...':
-    'prefix': 'emView.TextArea'
+    'prefix': 'emView_TextArea'
     'body':
       """
         Ember.TextArea.extend
@@ -36,7 +36,7 @@
 
 
   'Ember.Checkbox.extend(...':
-    'prefix': 'emView.Checkbox'
+    'prefix': 'emView_Checkbox'
     'body':
       """
         Ember.Checkbox.extend
@@ -47,7 +47,7 @@
 
 
   'Ember.Select.extend(...':
-    'prefix': 'emView.Select'
+    'prefix': 'emView_Select'
     'body':
       """
         Ember.Select.extend
@@ -58,7 +58,7 @@
 
 
   'eventManager: ...':
-    'prefix': 'emView.eventManager'
+    'prefix': 'emView_eventManager'
     'body':
       """
         eventManager: Ember.Object.create(
@@ -71,7 +71,7 @@
 
 
   'tagName : null':
-    'prefix': 'emView.tagN'
+    'prefix': 'emView_tagN'
     'body':
       """
         tagName: '${1:div}'
@@ -82,18 +82,18 @@
 
 
   'attributeBindings : [...':
-    'prefix': 'emView.attrB'
+    'prefix': 'emView_attrB'
     'body':
       """
-        attributeBindings: ['${1:prop}:${2:attr}']
-        ${1:prop}
+        attributeBindings: ['${1:prop_to}:${2:attr}']
+        ${1:prop_to}
       """
 
 
 
 
   'classNames : [...':
-    'prefix': 'emView.classN'
+    'prefix': 'emView_classN'
     'body':
       """
         classNames: ['${1:class-1}','${2:class-2}']
@@ -104,7 +104,7 @@
 
 
   'classNameBindings : [...':
-    'prefix': 'emView.classNB'
+    'prefix': 'emView_classNB'
     'body':
       """
         classNameBindings: ['${1:property_1:TruthyClass:FalsyClass}']
@@ -115,7 +115,7 @@
 
 
   'isVisible : null':
-    'prefix': 'emView.isVisible'
+    'prefix': 'emView_isVisible'
     'body':
       """
         isVisible: ${1:null}
@@ -123,8 +123,8 @@
 
 
 
-  'Ember View Hook':
-    'prefix': 'emView.e.willInsertElement'
+  'Ember willInsertElement Hook':
+    'prefix': 'emView_willInsertElement'
     'body':
       """
         willInsertElement: ->
@@ -133,8 +133,8 @@
 
 
 
-  'Ember View Hook':
-    'prefix': 'emView.e.didInsertElement'
+  'Ember didInsertElement Hook':
+    'prefix': 'emView_didInsertElement'
     'body':
       """
         didInsertElement: ->
@@ -143,8 +143,8 @@
 
 
 
-  'Ember View Hook':
-    'prefix': 'emView.e.willDestroyElement'
+  'Ember willDestroyElement Hook':
+    'prefix': 'emView_willDestroyElement'
     'body':
       """
         willDestroyElement: ->
@@ -153,8 +153,8 @@
 
 
 
-  'Ember View Hook':
-    'prefix': 'emView.e.parentViewDidChange'
+  'Ember parentViewDidChange Hook':
+    'prefix': 'emView_parentViewDidChange'
     'body':
       """
         parentViewDidChange: ->
@@ -163,8 +163,8 @@
 
 
 
-  'Ember View Hook':
-    'prefix': 'emView.e.willClearRender'
+  'Ember willClearRender Hook':
+    'prefix': 'emView_willClearRender'
     'body':
       """
         willClearRender: ->

--- a/snippets/view.cson
+++ b/snippets/view.cson
@@ -6,15 +6,59 @@
     'body':
       """
         _export = Ember.View.extend(
-          ${1:# to see more available snippets by Expanding :
-
-          # view-help${2}  (or view-h)
-          }
+          ${1}
         )
       """
 
-  'eventManager: ':
-    'prefix': 'emView.eventM'
+
+
+
+  'Ember.TextField.extend(...':
+    'prefix': 'emView.TextField'
+    'body':
+      """
+        Ember.TextField.extend
+          ${1:#logic...}
+      """
+
+
+
+
+  'Ember.TextArea.extend(...':
+    'prefix': 'emView.TextArea'
+    'body':
+      """
+        Ember.TextArea.extend
+          ${1:#logic...}
+      """
+
+
+
+
+  'Ember.Checkbox.extend(...':
+    'prefix': 'emView.Checkbox'
+    'body':
+      """
+        Ember.Checkbox.extend
+          ${1:#logic...}
+      """
+
+
+
+
+  'Ember.Select.extend(...':
+    'prefix': 'emView.Select'
+    'body':
+      """
+        Ember.Select.extend
+          ${1:#logic...}
+      """
+
+
+
+
+  'eventManager: ...':
+    'prefix': 'emView.eventManager'
     'body':
       """
         eventManager: Ember.Object.create(
@@ -26,11 +70,11 @@
 
 
 
-  'tagNames : "div"':
+  'tagName : null':
     'prefix': 'emView.tagN'
     'body':
       """
-        tagNames: '${1:div}'
+        tagName: '${1:div}'
         ${2}
       """
 
@@ -41,8 +85,8 @@
     'prefix': 'emView.attrB'
     'body':
       """
-        attributeBindings: ['${1}']
-        ${2}
+        attributeBindings: ['${1:prop}:${2:attr}']
+        ${1:prop}
       """
 
 
@@ -63,9 +107,8 @@
     'prefix': 'emView.classNB'
     'body':
       """
-        classNameBindings: ['${1}','${2}']
-        ${1} :
-        ${2} :
+        classNameBindings: ['${1:property_1:TruthyClass:FalsyClass}']
+        ${2:property_1} : ${3:true}
       """
 
 
@@ -76,4 +119,54 @@
     'body':
       """
         isVisible: ${1:null}
+      """
+
+
+
+  'Ember View Hook':
+    'prefix': 'emView.e.willInsertElement'
+    'body':
+      """
+        willInsertElement: ->
+          ${1:#logic...}
+      """
+
+
+
+  'Ember View Hook':
+    'prefix': 'emView.e.didInsertElement'
+    'body':
+      """
+        didInsertElement: ->
+          ${1:#logic...}
+      """
+
+
+
+  'Ember View Hook':
+    'prefix': 'emView.e.willDestroyElement'
+    'body':
+      """
+        willDestroyElement: ->
+          ${1:#logic...}
+      """
+
+
+
+  'Ember View Hook':
+    'prefix': 'emView.e.parentViewDidChange'
+    'body':
+      """
+        parentViewDidChange: ->
+          ${1:#logic...}
+      """
+
+
+
+  'Ember View Hook':
+    'prefix': 'emView.e.willClearRender'
+    'body':
+      """
+        willClearRender: ->
+          ${1:#logic...}
       """

--- a/snippets/view.cson
+++ b/snippets/view.cson
@@ -14,7 +14,7 @@
 
 
   'Ember.TextField.extend(...':
-    'prefix': 'em_view_TextField'
+    'prefix': 'em_view_textField'
     'body':
       """
         Ember.TextField.extend
@@ -25,7 +25,7 @@
 
 
   'Ember.TextArea.extend(...':
-    'prefix': 'em_view_TextArea'
+    'prefix': 'em_view_textArea'
     'body':
       """
         Ember.TextArea.extend
@@ -36,7 +36,7 @@
 
 
   'Ember.Checkbox.extend(...':
-    'prefix': 'em_view_Checkbox'
+    'prefix': 'em_view_checkbox'
     'body':
       """
         Ember.Checkbox.extend

--- a/snippets/view.cson
+++ b/snippets/view.cson
@@ -2,7 +2,7 @@
 
 
   'Ember.View.extend(...':
-    'prefix': 'emView'
+    'prefix': 'em_view'
     'body':
       """
         _export = Ember.View.extend(
@@ -14,7 +14,7 @@
 
 
   'Ember.TextField.extend(...':
-    'prefix': 'emView_TextField'
+    'prefix': 'em_view_TextField'
     'body':
       """
         Ember.TextField.extend
@@ -25,7 +25,7 @@
 
 
   'Ember.TextArea.extend(...':
-    'prefix': 'emView_TextArea'
+    'prefix': 'em_view_TextArea'
     'body':
       """
         Ember.TextArea.extend
@@ -36,7 +36,7 @@
 
 
   'Ember.Checkbox.extend(...':
-    'prefix': 'emView_Checkbox'
+    'prefix': 'em_view_Checkbox'
     'body':
       """
         Ember.Checkbox.extend
@@ -47,7 +47,7 @@
 
 
   'Ember.Select.extend(...':
-    'prefix': 'emView_Select'
+    'prefix': 'em_view_Select'
     'body':
       """
         Ember.Select.extend
@@ -58,7 +58,7 @@
 
 
   'eventManager: ...':
-    'prefix': 'emView_eventManager'
+    'prefix': 'em_view_eventManager'
     'body':
       """
         eventManager: Ember.Object.create(
@@ -71,7 +71,7 @@
 
 
   'tagName : null':
-    'prefix': 'emView_tagN'
+    'prefix': 'em_view_tagN'
     'body':
       """
         tagName: '${1:div}'
@@ -82,7 +82,7 @@
 
 
   'attributeBindings : [...':
-    'prefix': 'emView_attrB'
+    'prefix': 'em_view_attrB'
     'body':
       """
         attributeBindings: ['${1:prop_to}:${2:attr}']
@@ -93,7 +93,7 @@
 
 
   'classNames : [...':
-    'prefix': 'emView_classN'
+    'prefix': 'em_view_classN'
     'body':
       """
         classNames: ['${1:class-1}','${2:class-2}']
@@ -104,7 +104,7 @@
 
 
   'classNameBindings : [...':
-    'prefix': 'emView_classNB'
+    'prefix': 'em_view_classNB'
     'body':
       """
         classNameBindings: ['${1:property_1:TruthyClass:FalsyClass}']
@@ -115,7 +115,7 @@
 
 
   'isVisible : null':
-    'prefix': 'emView_isVisible'
+    'prefix': 'em_view_isVisible'
     'body':
       """
         isVisible: ${1:null}
@@ -124,7 +124,7 @@
 
 
   'Ember willInsertElement Hook':
-    'prefix': 'emView_willInsertElement'
+    'prefix': 'em_view_willInsertE'
     'body':
       """
         willInsertElement: ->
@@ -134,7 +134,7 @@
 
 
   'Ember didInsertElement Hook':
-    'prefix': 'emView_didInsertElement'
+    'prefix': 'em_view_didInsertE'
     'body':
       """
         didInsertElement: ->
@@ -144,7 +144,7 @@
 
 
   'Ember willDestroyElement Hook':
-    'prefix': 'emView_willDestroyElement'
+    'prefix': 'em_view_willDestroyElement'
     'body':
       """
         willDestroyElement: ->
@@ -154,7 +154,7 @@
 
 
   'Ember parentViewDidChange Hook':
-    'prefix': 'emView_parentViewDidChange'
+    'prefix': 'em_view_parentViewDidC'
     'body':
       """
         parentViewDidChange: ->
@@ -164,7 +164,7 @@
 
 
   'Ember willClearRender Hook':
-    'prefix': 'emView_willClearRender'
+    'prefix': 'em_view_willClearR'
     'body':
       """
         willClearRender: ->

--- a/snippets/view.cson
+++ b/snippets/view.cson
@@ -81,7 +81,7 @@
 
 
   'attributeBindings : [...':
-    'prefix': 'view_attributeB'
+    'prefix': 'view_attributeBind'
     'body':
       """
         attributeBindings: ['${1:prop_to}:${2:attr}']
@@ -103,7 +103,7 @@
 
 
   'classNameBindings : [...':
-    'prefix': 'view_classNameB'
+    'prefix': 'view_classNameBindings'
     'body':
       """
         classNameBindings: ['${1:property_1:TruthyClass:FalsyClass}']
@@ -154,7 +154,7 @@
 
 
   'Ember parentViewDidChange Hook':
-    'prefix': 'view_parentViewDidC'
+    'prefix': 'view_parentViewDidChange'
     'body':
       """
         parentViewDidChange: ->
@@ -164,7 +164,7 @@
 
 
   'Ember willClearRender Hook':
-    'prefix': 'view_willClearR'
+    'prefix': 'view_willClearRender'
     'body':
       """
         willClearRender: ->


### PR DESCRIPTION
https://github.com/atom-community/autocomplete-snippets
- note that this branch heavily depends on the package called autocomplete-snippets for it's effectiveness.
- every snippet is preceded with "em" for Ember or ds for DS. the reason for that is to Namespace the snippets so they do not collide if another package defines snippets for model,view,.... of backbone or angular.
- no need for --help or shorthands, thanks to the autocomplete-snippets package.
  try the snippets below:
  emView
  emArrayController
  dsModel
  emComputed
  ,...
