### PR TITLE
Fix ember-data snippets

### DIFF
--- a/snippets/ember-data.cson
+++ b/snippets/ember-data.cson
@@ -34,17 +34,17 @@
   'attr(...)':
     'prefix': 'attr'
     'leftLabel': 'Ember Data'
-    'body': "attr('${1:string}');"
+    'body': "attr('${1:string}'),"
 
   'belongsTo(...)':
     'prefix': 'belongsTo'
     'leftLabel': 'Ember Data'
-    'body': "belongsTo('${1:name}');"
+    'body': "belongsTo('${1:name}'),"
 
   'hasMany(...)':
     'prefix': 'hasMany'
     'leftLabel': 'Ember Data'
-    'body': "hasMany('${1:string}');"
+    'body': "hasMany('${1:string}'),"
 
 #############################
 # DEPRECATED


### PR DESCRIPTION
## Problem

`{attr, belongsTo, hasMany}⇥` snippets were ending with a semicolon (which is never the use case).

## Solution proposed

End `{attr, belongsTo, hasMany}⇥` snippets ending with a comma.