### PR TITLE
Import Inject Service

### DIFF
--- a/snippets/import-controller.cson
+++ b/snippets/import-controller.cson
@@ -8,4 +8,4 @@
   'Ember.inject.controller':
     'prefix': 'iminjectController'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { inject } from "@ember/controller";'
+    'body': 'import { inject as controller } from "@ember/controller";'

--- a/snippets/import-service.cson
+++ b/snippets/import-service.cson
@@ -8,4 +8,4 @@
   'Ember.inject.service':
     'prefix': 'iminjectService'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { inject } from "@ember/service";'
+    'body': 'import { inject as service } from "@ember/service";'


### PR DESCRIPTION
Hi! :)

The ember-modules-codemod recommends using these slightly modified snippets:

```
import { inject as service } from "@ember/service";
import { inject as controller } from "@ember/controller";
```

instead of
```
import { inject } from "@ember/service";
import { inject } from "@ember/controller";
```

See:
https://github.com/ember-cli/ember-modules-codemod/pull/46