### PR TITLE
Use single quotes for import snippets

### DIFF
--- a/snippets/import-application.cson
+++ b/snippets/import-application.cson
@@ -3,49 +3,49 @@
   'Ember.Application':
     'prefix': 'imapp'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Application from "@ember/application";'
+    'body': "import Application from '@ember/application';"
 
   'Ember.getOwner':
     'prefix': 'imgetOwner'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { getOwner } from "@ember/application";'
+    'body': "import { getOwner } from '@ember/application';"
 
   'Ember.onLoad':
     'prefix': 'imonLoad'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { onLoad } from "@ember/application";'
+    'body': "import { onLoad } from '@ember/application';"
 
   'Ember.runLoadHooks':
     'prefix': 'imrunLoadHooks'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { runLoadHooks } from "@ember/application";'
+    'body': "import { runLoadHooks } from '@ember/application';"
 
   'Ember.setOwner':
     'prefix': 'imsetOwner'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { setOwner } from "@ember/application";'
+    'body': "import { setOwner } from '@ember/application';"
 
   'Ember.deprecate':
     'prefix': 'imdeprecate'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { deprecate } from "@ember/application/deprecations";'
+    'body': "import { deprecate } from '@ember/application/deprecations';"
 
   'Ember.deprecateFunc':
     'prefix': 'imdeprecateFunc'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { deprecateFunc } from "@ember/application/deprecations";'
+    'body': "import { deprecateFunc } from '@ember/application/deprecations';"
 
   'Ember.DefaultResolver':
     'prefix': 'imdefaultResolver'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import GlobalsResolver from "@ember/application/globals-resolver";'
+    'body': "import GlobalsResolver from '@ember/application/globals-resolver';"
 
   'Ember.ApplicationInstance':
     'prefix': 'imappInstance'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import ApplicationInstance from "@ember/application/instance";'
+    'body': "import ApplicationInstance from '@ember/application/instance';"
 
   'Ember.Resolver':
     'prefix': 'imresolver'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Resolver from "@ember/application/resolver";'
+    'body': "import Resolver from '@ember/application/resolver';"

--- a/snippets/import-array.cson
+++ b/snippets/import-array.cson
@@ -3,29 +3,29 @@
   'Ember.Array':
     'prefix': 'imarray'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import EmberArray from "@ember/array";'
+    'body': "import EmberArray from '@ember/array';"
 
   'Ember.A':
     'prefix': 'imemberArray'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { A } from "@ember/array";'
+    'body': "import { A } from '@ember/array';"
 
   'Ember.isArray':
     'prefix': 'imisArray'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { isArray } from "@ember/array";'
+    'body': "import { isArray } from '@ember/array';"
 
   'Ember.makeArray':
     'prefix': 'immakeArray'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { makeArray } from "@ember/array";'
+    'body': "import { makeArray } from '@ember/array';"
 
   'Ember.MutableArray':
     'prefix': 'immutArray'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import MutableArray from "@ember/array/mutable";'
+    'body': "import MutableArray from '@ember/array/mutable';"
 
   'Ember.ArrayProxy':
     'prefix': 'imarrayProxy'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import ArrayProxy from "@ember/array/proxy";'
+    'body': "import ArrayProxy from '@ember/array/proxy';"

--- a/snippets/import-base.cson
+++ b/snippets/import-base.cson
@@ -3,34 +3,34 @@
   'Ember.$':
     'prefix': 'im$'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import $ from "jquery";'
+    'body': "import $ from 'jquery';"
 
   'Ember.Enumerable':
     'prefix': 'imenum'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Enumerable from "@ember/enumerable";'
+    'body': "import Enumerable from '@ember/enumerable';"
 
   'Ember.Error':
     'prefix': 'imerr'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import EmberError from "@ember/error";'
+    'body': "import EmberError from '@ember/error';"
 
   'Ember.instrument':
     'prefix': 'iminstrument'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { instrument } from "@ember/instrumentation";'
+    'body': "import { instrument } from '@ember/instrumentation';"
 
   'Ember.reset':
     'prefix': 'imreset'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { reset } from "@ember/instrumentation";'
+    'body': "import { reset } from '@ember/instrumentation';"
 
   'Ember.subscribe':
     'prefix': 'imsubscribe'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { subscribe } from "@ember/instrumentation";'
+    'body': "import { subscribe } from '@ember/instrumentation';"
 
   'Ember.unsubscribe':
     'prefix': 'imunsubscribe'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { unsubscribe } from "@ember/instrumentation";'
+    'body': "import { unsubscribe } from '@ember/instrumentation';"

--- a/snippets/import-component.cson
+++ b/snippets/import-component.cson
@@ -3,29 +3,29 @@
   'Ember.Component':
     'prefix': 'imcomponent'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Component from "@ember/component";'
+    'body': "import Component from '@ember/component';"
 
   'Ember.Checkbox':
     'prefix': 'imcheckbox'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Checkbox from "@ember/component/checkbox";'
+    'body': "import Checkbox from '@ember/component/checkbox';"
 
   'Ember.Helper':
     'prefix': 'imhelper'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Helper from "@ember/component/helper";'
+    'body': "import Helper from '@ember/component/helper';"
 
   'Ember.Helper.helper':
     'prefix': 'imhelperHelper'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { helper } from "@ember/component/helper";'
+    'body': "import { helper } from '@ember/component/helper';"
 
   'Ember.TextArea':
     'prefix': 'imtextArea'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import TextArea from "@ember/component/text-area";'
+    'body': "import TextArea from '@ember/component/text-area';"
 
   'Ember.TextField':
     'prefix': 'imtextField'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import TextField from "@ember/component/text-field";'
+    'body': "import TextField from '@ember/component/text-field';"

--- a/snippets/import-controller.cson
+++ b/snippets/import-controller.cson
@@ -3,9 +3,9 @@
   'Ember.Controller':
     'prefix': 'imcontroller'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Controller from "@ember/controller";'
+    'body': "import Controller from '@ember/controller';"
 
   'Ember.inject.controller':
     'prefix': 'iminjectController'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { inject as controller } from "@ember/controller";'
+    'body': "import { inject as controller } from '@ember/controller';"

--- a/snippets/import-debug.cson
+++ b/snippets/import-debug.cson
@@ -3,46 +3,46 @@
   'Ember.assert':
     'prefix': 'imassert'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { assert } from "@ember/debug";'
+    'body': "import { assert } from '@ember/debug';"
 
   'Ember.debug':
     'prefix': 'imdebug'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { debug } from "@ember/debug";'
+    'body': "import { debug } from '@ember/debug';"
 
   'Ember.inspect':
     'prefix': 'iminspect'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { inspect } from "@ember/debug";'
+    'body': "import { inspect } from '@ember/debug';"
 
   'Ember.Debug.registerDeprecationHandler':
     'prefix': 'imregisterDeprecationHandler'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { registerDeprecationHandler } from "@ember/debug";'
+    'body': "import { registerDeprecationHandler } from '@ember/debug';"
 
   'Ember.Debug.registerWarnHandler':
     'prefix': 'imregisterWarnHandler'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { registerWarnHandler } from "@ember/debug";'
+    'body': "import { registerWarnHandler } from '@ember/debug';"
 
   'Ember.runInDebug':
     'prefix': 'imrunInDebug'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { runInDebug } from "@ember/debug";'
+    'body': "import { runInDebug } from '@ember/debug';"
 
   'Ember.warn':
     'prefix': 'imwarn'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { warn } from "@ember/debug";'
+    'body': "import { warn } from '@ember/debug';"
 
   'Ember.ContainerDebugAdapter':
     'prefix': 'imcontainerDebugAdapter'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
     'body': """
-      import ContainerDebugAdapter from "@ember/debug/container-debug-adapter";
+      import ContainerDebugAdapter from '@ember/debug/container-debug-adapter';
     """
 
   'Ember.DataAdapter':
     'prefix': 'imdebugDataAdapter'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import DataAdapter from "@ember/debug/data-adapter";'
+    'body': "import DataAdapter from '@ember/debug/data-adapter';"

--- a/snippets/import-engine.cson
+++ b/snippets/import-engine.cson
@@ -3,14 +3,14 @@
   'Ember.Engine':
     'prefix': 'imengine'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Engine from "@ember/engine";'
+    'body': "import Engine from '@ember/engine';"
 
   'Ember.EngineInstance':
     'prefix': 'imengineInst'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import EngineInstance from "@ember/engine/instance";'
+    'body': "import EngineInstance from '@ember/engine/instance';"
 
   'Ember.getEngineParent':
     'prefix': 'imgetEngineParent'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { getEngineParent } from "@ember/engine";'
+    'body': "import { getEngineParent } from '@ember/engine';"

--- a/snippets/import-map.cson
+++ b/snippets/import-map.cson
@@ -3,9 +3,9 @@
   'Ember.Map':
     'prefix': 'immap'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import EmberMap from "@ember/map";'
+    'body': "import EmberMap from '@ember/map';"
 
   'Ember.MapWithDefault':
     'prefix': 'immapWDefault'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import MapWithDefault from "@ember/map/with-default";'
+    'body': "import MapWithDefault from '@ember/map/with-default';"

--- a/snippets/import-object.cson
+++ b/snippets/import-object.cson
@@ -3,309 +3,309 @@
   'Ember.Object':
     'prefix': 'imobject'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import EmberObject from "@ember/object";'
+    'body': "import EmberObject from '@ember/object';"
 
   'Ember.ObjectProxy':
     'prefix': 'imobjectProxy'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import ObjectProxy from "@ember/object/proxy";'
+    'body': "import ObjectProxy from '@ember/object/proxy';"
 
   'Ember.Observable':
     'prefix': 'imobservable'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Observable from "@ember/object/observable";'
+    'body': "import Observable from '@ember/object/observable';"
 
   'Ember.addListener':
     'prefix': 'imaddListener'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { addListener } from "@ember/object/events";'
+    'body': "import { addListener } from '@ember/object/events';"
 
   'Ember.addObserver':
     'prefix': 'imaddObserver'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { addObserver } from "@ember/object/observers";'
+    'body': "import { addObserver } from '@ember/object/observers';"
 
   'Ember.aliasMethod':
     'prefix': 'imaliasMethod'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { aliasMethod } from "@ember/object";'
+    'body': "import { aliasMethod } from '@ember/object';"
 
   'Ember.computed':
     'prefix': 'imcomputed'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { computed } from "@ember/object";'
+    'body': "import { computed } from '@ember/object';"
 
   'Ember.computed.alias':
     'prefix': 'imalias'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { alias } from "@ember/object/computed";'
+    'body': "import { alias } from '@ember/object/computed';"
 
   'Ember.computed.and':
     'prefix': 'imand'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { and } from "@ember/object/computed";'
+    'body': "import { and } from '@ember/object/computed';"
 
   'Ember.computed.bool':
     'prefix': 'imbool'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { bool } from "@ember/object/computed";'
+    'body': "import { bool } from '@ember/object/computed';"
 
   'Ember.computed.collect':
     'prefix': 'imcollect'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { collect } from "@ember/object/computed";'
+    'body': "import { collect } from '@ember/object/computed';"
 
   'Ember.computed.deprecatingAlias':
     'prefix': 'imdeprecatingAlias'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { deprecatingAlias } from "@ember/object/computed";'
+    'body': "import { deprecatingAlias } from '@ember/object/computed';"
 
   'Ember.computed.empty':
     'prefix': 'imempty'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { empty } from "@ember/object/computed";'
+    'body': "import { empty } from '@ember/object/computed';"
 
   'Ember.computed.equal':
     'prefix': 'imequal'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { equal } from "@ember/object/computed";'
+    'body': "import { equal } from '@ember/object/computed';"
 
   'Ember.computed.filter':
     'prefix': 'imfilter'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { filter } from "@ember/object/computed";'
+    'body': "import { filter } from '@ember/object/computed';"
 
   'Ember.computed.filterBy':
     'prefix': 'imfilterBy'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { filterBy } from "@ember/object/computed";'
+    'body': "import { filterBy } from '@ember/object/computed';"
 
   'Ember.computed.filterProperty':
     'prefix': 'imfilterProperty'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { filterProperty } from "@ember/object/computed";'
+    'body': "import { filterProperty } from '@ember/object/computed';"
 
   'Ember.computed.gt':
     'prefix': 'imgt'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { gt } from "@ember/object/computed";'
+    'body': "import { gt } from '@ember/object/computed';"
 
   'Ember.computed.gte':
     'prefix': 'imgte'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { gte } from "@ember/object/computed";'
+    'body': "import { gte } from '@ember/object/computed';"
 
   'Ember.computed.intersect':
     'prefix': 'imintersect'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { intersect } from "@ember/object/computed";'
+    'body': "import { intersect } from '@ember/object/computed';"
 
   'Ember.computed.lt':
     'prefix': 'imlt'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { lt } from "@ember/object/computed";'
+    'body': "import { lt } from '@ember/object/computed';"
 
   'Ember.computed.lte':
     'prefix': 'imlte'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { lte } from "@ember/object/computed";'
+    'body': "import { lte } from '@ember/object/computed';"
 
   'Ember.computed.map':
     'prefix': 'immap'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { map } from "@ember/object/computed";'
+    'body': "import { map } from '@ember/object/computed';"
 
   'Ember.computed.mapBy':
     'prefix': 'immapBy'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { mapBy } from "@ember/object/computed";'
+    'body': "import { mapBy } from '@ember/object/computed';"
 
   'Ember.computed.mapProperty':
     'prefix': 'immapProperty'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { mapProperty } from "@ember/object/computed";'
+    'body': "import { mapProperty } from '@ember/object/computed';"
 
   'Ember.computed.match':
     'prefix': 'immatch'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { match } from "@ember/object/computed";'
+    'body': "import { match } from '@ember/object/computed';"
 
   'Ember.computed.max':
     'prefix': 'immax'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { max } from "@ember/object/computed";'
+    'body': "import { max } from '@ember/object/computed';"
 
   'Ember.computed.min':
     'prefix': 'immin'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { min } from "@ember/object/computed";'
+    'body': "import { min } from '@ember/object/computed';"
 
   'Ember.computed.none':
     'prefix': 'imnone'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { none } from "@ember/object/computed";'
+    'body': "import { none } from '@ember/object/computed';"
 
   'Ember.computed.not':
     'prefix': 'imnot'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { not } from "@ember/object/computed";'
+    'body': "import { not } from '@ember/object/computed';"
 
   'Ember.computed.notEmpty':
     'prefix': 'imnotEmpty'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { notEmpty } from "@ember/object/computed";'
+    'body': "import { notEmpty } from '@ember/object/computed';"
 
   'Ember.computed.oneWay':
     'prefix': 'imoneWay'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { oneWay } from "@ember/object/computed";'
+    'body': "import { oneWay } from '@ember/object/computed';"
 
   'Ember.computed.or':
     'prefix': 'imor'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { or } from "@ember/object/computed";'
+    'body': "import { or } from '@ember/object/computed';"
 
   'Ember.computed.readOnly':
     'prefix': 'imreadOnly'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { readOnly } from "@ember/object/computed";'
+    'body': "import { readOnly } from '@ember/object/computed';"
 
   'Ember.computed.reads':
     'prefix': 'imreads'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { reads } from "@ember/object/computed";'
+    'body': "import { reads } from '@ember/object/computed';"
 
   'Ember.computed.setDiff':
     'prefix': 'imsetDiff'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { setDiff } from "@ember/object/computed";'
+    'body': "import { setDiff } from '@ember/object/computed';"
 
   'Ember.computed.sort':
     'prefix': 'imsort'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { sort } from "@ember/object/computed";'
+    'body': "import { sort } from '@ember/object/computed';"
 
   'Ember.computed.sum':
     'prefix': 'imsum'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { sum } from "@ember/object/computed";'
+    'body': "import { sum } from '@ember/object/computed';"
 
   'Ember.computed.union':
     'prefix': 'imunion'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { union } from "@ember/object/computed";'
+    'body': "import { union } from '@ember/object/computed';"
 
   'Ember.computed.uniq':
     'prefix': 'imuniq'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { uniq } from "@ember/object/computed";'
+    'body': "import { uniq } from '@ember/object/computed';"
 
   'Ember.computed.uniqBy':
     'prefix': 'imuniqBy'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { uniqBy } from "@ember/object/computed";'
+    'body': "import { uniqBy } from '@ember/object/computed';"
 
   'Ember.copy':
     'prefix': 'imcopy'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { copy } from "@ember/object/internals";'
+    'body': "import { copy } from '@ember/object/internals';"
 
   'Ember.create':
     'prefix': 'impolyfillCreate'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { create } from "@ember/polyfills";'
+    'body': "import { create } from '@ember/polyfills';"
 
   'Ember.defineProperty':
     'prefix': 'imobjecDefineProperty'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { defineProperty } from "@ember/object";'
+    'body': "import { defineProperty } from '@ember/object';"
 
   'Ember.get':
     'prefix': 'imget'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { get } from "@ember/object";'
+    'body': "import { get } from '@ember/object';"
 
   'Ember.getProperties':
     'prefix': 'imgetProperties'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { getProperties } from "@ember/object";'
+    'body': "import { getProperties } from '@ember/object';"
 
   'Ember.getWithDefault':
     'prefix': 'imgetWithDefault'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { getWithDefault } from "@ember/object";'
+    'body': "import { getWithDefault } from '@ember/object';"
 
   'Ember.guidFor':
     'prefix': 'imguidFor'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { guidFor } from "@ember/object/internals";'
+    'body': "import { guidFor } from '@ember/object/internals';"
 
   'Ember.observer':
     'prefix': 'imobserver'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { observer } from "@ember/object";'
+    'body': "import { observer } from '@ember/object';"
 
   'Ember.on':
     'prefix': 'imon'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { on } from "@ember/object/evented";'
+    'body': "import { on } from '@ember/object/evented';"
 
   'Ember.removeListener':
     'prefix': 'imremoveListener'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { removeListener } from "@ember/object/events";'
+    'body': "import { removeListener } from '@ember/object/events';"
 
   'Ember.removeObserver':
     'prefix': 'imremoveObserver'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { removeObserver } from "@ember/object/observers";'
+    'body': "import { removeObserver } from '@ember/object/observers';"
 
   'Ember.sendEvent':
     'prefix': 'imsendEvent'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { sendEvent } from "@ember/object/events";'
+    'body': "import { sendEvent } from '@ember/object/events';"
 
   'Ember.set':
     'prefix': 'imset'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { set } from "@ember/object";'
+    'body': "import { set } from '@ember/object';"
 
   'Ember.setProperties':
     'prefix': 'imsetProperties'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { setProperties } from "@ember/object";'
+    'body': "import { setProperties } from '@ember/object';"
 
   'Ember.trySet':
     'prefix': 'imtrySet'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { trySet } from "@ember/object";'
+    'body': "import { trySet } from '@ember/object';"
 
   'Ember.ComputedProperty':
     'prefix': 'imcomputedProperty'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import ComputedProperty from "@ember/object/computed";'
+    'body': "import ComputedProperty from '@ember/object/computed';"
 
   'Ember.CoreObject':
     'prefix': 'imcoreObject'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import CoreObject from "@ember/object/core";'
+    'body': "import CoreObject from '@ember/object/core';"
 
   'Ember.Evented':
     'prefix': 'imevented'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Evented from "@ember/object/evented";'
+    'body': "import Evented from '@ember/object/evented';"
 
   'Ember.Mixin':
     'prefix': 'immixin'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Mixin from "@ember/object/mixin";'
+    'body': "import Mixin from '@ember/object/mixin';"
 
   'Ember.PromiseProxyMixin':
     'prefix': 'impromiseProxyMixin'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import PromiseProxyMixin from "@ember/object/promise-proxy-mixin";'
+    'body': "import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';"
 
   'Ember.cacheFor':
     'prefix': 'imcacheFor'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { cacheFor } from "@ember/object/internals";'
+    'body': "import { cacheFor } from '@ember/object/internals';"

--- a/snippets/import-polyfills.cson
+++ b/snippets/import-polyfills.cson
@@ -3,24 +3,24 @@
   'Ember.assign':
     'prefix': 'imassign'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { assign } from "@ember/polyfills";'
+    'body': "import { assign } from '@ember/polyfills';"
 
   'Ember.keys':
     'prefix': 'imkeys'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { keys } from "@ember/polyfills";'
+    'body': "import { keys } from '@ember/polyfills';"
 
   'Ember.merge':
     'prefix': 'immerge'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { merge } from "@ember/polyfills";'
+    'body': "import { merge } from '@ember/polyfills';"
 
   'Ember.create':
     'prefix': 'imcreate'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { create } from "@ember/polyfills";'
+    'body': "import { create } from '@ember/polyfills';"
 
   'Ember.platform.hasPropertyAccessors':
     'prefix': 'imhasPropertyAccessors'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { hasPropertyAccessors } from "@ember/polyfills";'
+    'body': "import { hasPropertyAccessors } from '@ember/polyfills';"

--- a/snippets/import-routing.cson
+++ b/snippets/import-routing.cson
@@ -3,39 +3,39 @@
   'Ember.AutoLocation':
     'prefix': 'imautoLocation'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import AutoLocation from "@ember/routing/auto-location";'
+    'body': "import AutoLocation from '@ember/routing/auto-location';"
 
   'Ember.HashLocation':
     'prefix': 'imroutingHash'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import HashLocation from "@ember/routing/hash-location";'
+    'body': "import HashLocation from '@ember/routing/hash-location';"
 
   'Ember.HistoryLocation':
     'prefix': 'imroutingHistory'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import HistoryLocation from "@ember/routing/history-location";'
+    'body': "import HistoryLocation from '@ember/routing/history-location';"
 
   'Ember.LinkComponent':
     'prefix': 'imlinkComponent'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import LinkComponent from "@ember/routing/link-component";'
+    'body': "import LinkComponent from '@ember/routing/link-component';"
 
   'Ember.Location':
     'prefix': 'imlocation'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Location from "@ember/routing/location";'
+    'body': "import Location from '@ember/routing/location';"
 
   'Ember.NoneLocation':
     'prefix': 'imnoneLocation'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import NoneLocation from "@ember/routing/none-location";'
+    'body': "import NoneLocation from '@ember/routing/none-location';"
 
   'Ember.Route':
     'prefix': 'imroute'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Route from "@ember/routing/route";'
+    'body': "import Route from '@ember/routing/route';"
 
   'Ember.Router':
     'prefix': 'imrouter'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Router from "@ember/routing/router";'
+    'body': "import Router from '@ember/routing/router';"

--- a/snippets/import-rsvp.cson
+++ b/snippets/import-rsvp.cson
@@ -3,74 +3,74 @@
   'Ember.RSVP':
     'prefix': 'imrsvp'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import RSVP from "rsvp";'
+    'body': "import RSVP from 'rsvp';"
 
   'Ember.RSVP.Promise':
     'prefix': 'impromise'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { Promise } from "rsvp";'
+    'body': "import { Promise } from 'rsvp';"
 
   'Ember.RSVP.all':
     'prefix': 'imrsvpAll'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { all } from "rsvp";'
+    'body': "import { all } from 'rsvp';"
 
   'Ember.RSVP.allSettled':
     'prefix': 'imrsvpAllSettled'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { allSettled } from "rsvp";'
+    'body': "import { allSettled } from 'rsvp';"
 
   'Ember.RSVP.defer':
     'prefix': 'imrsvpDefer'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { defer } from "rsvp";'
+    'body': "import { defer } from 'rsvp';"
 
   'Ember.RSVP.denodeify':
     'prefix': 'imrsvpDenodeify'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { denodeify } from "rsvp";'
+    'body': "import { denodeify } from 'rsvp';"
 
   'Ember.RSVP.filter':
     'prefix': 'imrsvpFilter'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { filter } from "rsvp";'
+    'body': "import { filter } from 'rsvp';"
 
   'Ember.RSVP.hash':
     'prefix': 'imrsvpHash'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { hash } from "rsvp";'
+    'body': "import { hash } from 'rsvp';"
 
   'Ember.RSVP.hashSettled':
     'prefix': 'imrsvpHashSettled'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { hashSettled } from "rsvp";'
+    'body': "import { hashSettled } from 'rsvp';"
 
   'Ember.RSVP.map':
     'prefix': 'imrsvpMap'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { map } from "rsvp";'
+    'body': "import { map } from 'rsvp';"
 
   'Ember.RSVP.off':
     'prefix': 'imrsvpOff'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { off } from "rsvp";'
+    'body': "import { off } from 'rsvp';"
 
   'Ember.RSVP.on':
     'prefix': 'imrsvpOn'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { on } from "rsvp";'
+    'body': "import { on } from 'rsvp';"
 
   'Ember.RSVP.race':
     'prefix': 'imrsvpRace'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { race } from "rsvp";'
+    'body': "import { race } from 'rsvp';"
 
   'Ember.RSVP.reject':
     'prefix': 'imrsvpReject'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { reject } from "rsvp";'
+    'body': "import { reject } from 'rsvp';"
 
   'Ember.RSVP.resolve':
     'prefix': 'imrsvpResolve'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { resolve } from "rsvp";'
+    'body': "import { resolve } from 'rsvp';"

--- a/snippets/import-runloop.cson
+++ b/snippets/import-runloop.cson
@@ -3,64 +3,64 @@
   'Ember.run':
     'prefix': 'imrun'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { run } from "@ember/runloop";'
+    'body': "import { run } from '@ember/runloop';"
 
   'Ember.run.begin':
     'prefix': 'imbegin'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { begin } from "@ember/runloop";'
+    'body': "import { begin } from '@ember/runloop';"
 
   'Ember.run.bind':
     'prefix': 'imbind'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { bind } from "@ember/runloop";'
+    'body': "import { bind } from '@ember/runloop';"
 
   'Ember.run.cancel':
     'prefix': 'imcancel'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { cancel } from "@ember/runloop";'
+    'body': "import { cancel } from '@ember/runloop';"
 
   'Ember.run.debounce':
     'prefix': 'imdebounce'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { debounce } from "@ember/runloop";'
+    'body': "import { debounce } from '@ember/runloop';"
 
   'Ember.run.end':
     'prefix': 'imend'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { end } from "@ember/runloop";'
+    'body': "import { end } from '@ember/runloop';"
 
   'Ember.run.join':
     'prefix': 'imjoin'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { join } from "@ember/runloop";'
+    'body': "import { join } from '@ember/runloop';"
 
   'Ember.run.later':
     'prefix': 'imlater'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { later } from "@ember/runloop";'
+    'body': "import { later } from '@ember/runloop';"
 
   'Ember.run.next':
     'prefix': 'imnext'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { next } from "@ember/runloop";'
+    'body': "import { next } from '@ember/runloop';"
 
   'Ember.run.once':
     'prefix': 'imonce'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { once } from "@ember/runloop";'
+    'body': "import { once } from '@ember/runloop';"
 
   'Ember.run.schedule':
     'prefix': 'imschedule'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { schedule } from "@ember/runloop";'
+    'body': "import { schedule } from '@ember/runloop';"
 
   'Ember.run.scheduleOnce':
     'prefix': 'imscheduleOnce'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { scheduleOnce } from "@ember/runloop";'
+    'body': "import { scheduleOnce } from '@ember/runloop';"
 
   'Ember.run.throttle':
     'prefix': 'imthrottle'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { throttle } from "@ember/runloop";'
+    'body': "import { throttle } from '@ember/runloop';"

--- a/snippets/import-service.cson
+++ b/snippets/import-service.cson
@@ -3,9 +3,9 @@
   'Ember.Service':
     'prefix': 'imservice'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Service from "@ember/service";'
+    'body': "import Service from '@ember/service';"
 
   'Ember.inject.service':
     'prefix': 'iminjectService'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { inject as service } from "@ember/service";'
+    'body': "import { inject as service } from '@ember/service';"

--- a/snippets/import-string.cson
+++ b/snippets/import-string.cson
@@ -3,54 +3,54 @@
   'Ember.String.camelize':
     'prefix': 'imcamelize'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { camelize } from "@ember/string";'
+    'body': "import { camelize } from '@ember/string';"
 
   'Ember.String.capitalize':
     'prefix': 'imcapitalize'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { capitalize } from "@ember/string";'
+    'body': "import { capitalize } from '@ember/string';"
 
   'Ember.String.classify':
     'prefix': 'imclassify'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { classify } from "@ember/string";'
+    'body': "import { classify } from '@ember/string';"
 
   'Ember.String.dasherize':
     'prefix': 'imdasherize'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { dasherize } from "@ember/string";'
+    'body': "import { dasherize } from '@ember/string';"
 
   'Ember.String.decamelize':
     'prefix': 'imdecamelize'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { decamelize } from "@ember/string";'
+    'body': "import { decamelize } from '@ember/string';"
 
   'Ember.String.fmt':
     'prefix': 'imfmt'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { fmt } from "@ember/string";'
+    'body': "import { fmt } from '@ember/string';"
 
   'Ember.String.htmlSafe':
     'prefix': 'imhtmlSafe'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { htmlSafe } from "@ember/string";'
+    'body': "import { htmlSafe } from '@ember/string';"
 
   'Ember.String.isHtmlSafe':
     'prefix': 'imisHtmlSafe'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { isHtmlSafe } from "@ember/string";'
+    'body': "import { isHtmlSafe } from '@ember/string';"
 
   'Ember.String.loc':
     'prefix': 'imloc'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { loc } from "@ember/string";'
+    'body': "import { loc } from '@ember/string';"
 
   'Ember.String.underscore':
     'prefix': 'imunderscore'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { underscore } from "@ember/string";'
+    'body': "import { underscore } from '@ember/string';"
 
   'Ember.String.w':
     'prefix': 'imw'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { w } from "@ember/string";'
+    'body': "import { w } from '@ember/string';"

--- a/snippets/import-test.cson
+++ b/snippets/import-test.cson
@@ -3,29 +3,29 @@
   'Ember.Test.Adapter':
     'prefix': 'imtestAdapter'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import Test.Adapter from "@ember/test/adapter";'
+    'body': "import Test.Adapter from '@ember/test/adapter';"
 
   'Ember.Test.registerAsyncHelper':
     'prefix': 'imregisterAsyncHelper'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { registerAsyncHelper } from "@ember/test";'
+    'body': "import { registerAsyncHelper } from '@ember/test';"
 
   'Ember.Test.registerHelper':
     'prefix': 'imregisterHelper'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { registerHelper } from "@ember/test";'
+    'body': "import { registerHelper } from '@ember/test';"
 
   'Ember.Test.registerWaiter':
     'prefix': 'imregisterWaiter'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { registerWaiter } from "@ember/test";'
+    'body': "import { registerWaiter } from '@ember/test';"
 
   'Ember.Test.unregisterHelper':
     'prefix': 'imunregisterHelper'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { unregisterHelper } from "@ember/test";'
+    'body': "import { unregisterHelper } from '@ember/test';"
 
   'Ember.Test.unregisterWaiter':
     'prefix': 'imunregisterWaiter'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { unregisterWaiter } from "@ember/test";'
+    'body': "import { unregisterWaiter } from '@ember/test';"

--- a/snippets/import-utils.cson
+++ b/snippets/import-utils.cson
@@ -3,39 +3,39 @@
   'Ember.compare':
     'prefix': 'imcompare'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { compare } from "@ember/utils";'
+    'body': "import { compare } from '@ember/utils';"
 
   'Ember.isBlank':
     'prefix': 'imisBlank'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { isBlank } from "@ember/utils";'
+    'body': "import { isBlank } from '@ember/utils';"
 
   'Ember.isEmpty':
     'prefix': 'imisEmpty'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { isEmpty } from "@ember/utils";'
+    'body': "import { isEmpty } from '@ember/utils';"
 
   'Ember.isEqual':
     'prefix': 'imisEqual'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { isEqual } from "@ember/utils";'
+    'body': "import { isEqual } from '@ember/utils';"
 
   'Ember.isNone':
     'prefix': 'imisNone'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { isNone } from "@ember/utils";'
+    'body': "import { isNone } from '@ember/utils';"
 
   'Ember.isPresent':
     'prefix': 'imisPresent'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { isPresent } from "@ember/utils";'
+    'body': "import { isPresent } from '@ember/utils';"
 
   'Ember.tryInvoke':
     'prefix': 'imtryInvoke'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { tryInvoke } from "@ember/utils";'
+    'body': "import { tryInvoke } from '@ember/utils';"
 
   'Ember.typeOf':
     'prefix': 'imtypeOf'
     'leftLabelHTML': '<span style="color:#E46651">Ember module</span>'
-    'body': 'import { typeOf } from "@ember/utils";'
+    'body': "import { typeOf } from '@ember/utils';"


### PR DESCRIPTION
I find myself always overwriting the double quotes in the import snippets. I think using only single quotes is the more common case when writing javascript code, and other snippets in this package also use single quotes.